### PR TITLE
Fix typo in ProbabilitiesEstimator docstring

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ComplexityMeasures"
 uuid = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/ComplexityMeasures.jl.git"
-version = "2.3.1"
+version = "2.3.2"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/probabilities.jl
+++ b/src/probabilities.jl
@@ -64,7 +64,7 @@ input data and one of the following probabilities estimators. The result is a
 the outcome `ω[i]`. Use [`probabilities_and_outcomes`](@ref) if you need
 both the probabilities and the outcomes, and use [`outcome_space`](@ref) to obtain
 ``\\Omega`` alone.
-The element type of ``\\Omega`` varies between estimators, but it is guranteed to be
+The element type of ``\\Omega`` varies between estimators, but it is guaranteed to be
 _hashable_. This allows for conveniently tracking the probability of a specific event
 across experimental realizations, by using the outcome as a dictionary key and the
 probability as the value for that key (or, alternatively, the key remains the outcome


### PR DESCRIPTION
Let me know if I should also bump the minor version.