### PR TITLE
Complete re-write of rectangular binnings to use ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Changelog is kept with respect to version 0.11 of Entropies.jl. From version v2.0 onwards, this package has been renamed to ComplexityMeasures.jl.
 
+## 2.4
+- Rectangular binnings have been reformed to operate based on ranges. This leads to much more intuitive bin sizes and edges. For `RectangularBinning` nothing changes, while for `FixedRectangularBinning` the ranges should be given explicitly. Backwards compatible deprecations have been added.
+- This also allows for a new `precise` option that utilizes Base Julia `TwinPrecision` to make more accurate mapping of points to bins at the cost of performance.
+
 ## 2.3
 - Like differential entropies, discrete entropies now also have their own estimator type.
 - The approach of giving both an entropy definition, and an entropy estimator to `entropy` has been dropped. Now the entropy estimators know what definitions they are applied for. This change is a deprecation, i.e., backwards compatible.

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ComplexityMeasures"
 uuid = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/ComplexityMeasures.jl.git"
-version = "2.3.2"
+version = "2.4.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/ComplexityMeasures.jl
+++ b/src/ComplexityMeasures.jl
@@ -21,7 +21,6 @@ include("encodings.jl")
 include("complexity.jl")
 include("multiscale.jl")
 include("convenience.jl")
-include("deprecations.jl")
 
 # Library implementations (files include other files)
 include("encoding_implementations/encoding_implementations.jl")
@@ -29,6 +28,9 @@ include("probabilities_estimators/probabilities_estimators.jl")
 include("entropies_definitions/entropies_definitions.jl")
 include("entropies_estimators/entropies_estimators.jl")
 include("complexity_measures/complexity_measures.jl")
+
+# deprecations (must be after all declarations)
+include("deprecations.jl")
 
 # Update messages:
 using Scratch

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -4,9 +4,9 @@ function FixedRectangularBinning(ϵmin::NTuple{D,T}, ϵmax::NTuple{D,T}, N::Int)
 end
 function FixedRectangularBinning(ϵmin::Real, ϵmax::Real, N, D::Int = 1)
     if N isa Int
-        FixedRectangularBinning(ntuple(x-> range(ϵmin, ϵmax; length = N), D))
+        FixedRectangularBinning(ntuple(x-> range(ϵmin, nextfloat(ϵmax); length = N), D))
     else
-        FixedRectangularBinning(ntuple(x-> range(ϵmin, ϵmax; step = N), D))
+        FixedRectangularBinning(ntuple(x-> range(ϵmin, nextfloat(ϵmax); step = N), D))
     end
 end
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -4,9 +4,9 @@ function FixedRectangularBinning(ϵmin::NTuple{D,T}, ϵmax::NTuple{D,T}, N::Int)
 end
 function FixedRectangularBinning(ϵmin::Real, ϵmax::Real, N, D::Int = 1)
     if N isa Int
-        FixedRectangularBinning(ntuple(x-> range(ϵmin, nextfloat(ϵmax); length = N), D))
+        FixedRectangularBinning(ntuple(x-> range(ϵmin, nextfloat(float(ϵmax)); length = N), D))
     else
-        FixedRectangularBinning(ntuple(x-> range(ϵmin, nextfloat(ϵmax); step = N), D))
+        FixedRectangularBinning(ntuple(x-> range(ϵmin, nextfloat(float(ϵmax)); step = N), D))
     end
 end
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,3 +1,16 @@
+# from before histogram-from-ranges rework
+function FixedRectangularBinning(ϵmin::NTuple{D,T}, ϵmax::NTuple{D,T}, N::Int) where {D, T}
+    FixedRectangularBinning(ntuple(x->range(ϵmin[i],ϵmax[i];length=N), D))
+end
+function FixedRectangularBinning(ϵmin::Real, ϵmax::Real, N, D::Int = 1)
+    if N isa Int
+        FixedRectangularBinning(ntuple(x-> range(ϵmin, ϵmax; length = N), D))
+    else
+        FixedRectangularBinning(ntuple(x-> range(ϵmin, ϵmax; step = N), D))
+    end
+end
+
+
 # from before https://github.com/JuliaDynamics/ComplexityMeasures.jl/pull/239
 function entropy(e::EntropyDefinition, est::DiffEntropyEst, x)
     if e isa Shannon

--- a/src/encoding_implementations/rectangular_binning.jl
+++ b/src/encoding_implementations/rectangular_binning.jl
@@ -179,7 +179,7 @@ end
 # encode/decode
 ##################################################################
 function encode(e::RectangularBinEncoding, point)
-
+    cartidx = cartesian_bin_index(e, point)
     # We have decided on the arbitrary convention that out of bound points
     # will get the special symbol `-1`. Erroring doesn't make sense as it is expected
     # that for fixed histograms there may be points outside of them.
@@ -193,8 +193,9 @@ end
 """
     cartesian_bin_index(e::RectangularBinEncoding, point::SVector)
 
-Internal function called by `encode`. Returns the cartesian index of
+Return the cartesian index of
 the given `point` within the binning encapsulated in `e`.
+Internal function called by `encode`.
 """
 function cartesian_bin_index(e::RectangularBinEncoding, point)
     ranges = e.ranges
@@ -207,8 +208,6 @@ function cartesian_bin_index(e::RectangularBinEncoding, point)
     end
     return cartidx
 end
-
-
 
 function decode(e::RectangularBinEncoding, bin::Int)
     if checkbounds(Bool, e.ci, bin)

--- a/src/encoding_implementations/rectangular_binning.jl
+++ b/src/encoding_implementations/rectangular_binning.jl
@@ -146,7 +146,7 @@ function RectangularBinEncoding(b::RectangularBinning, x; n_eps = 2)
     v = ones(SVector{D,T})
     if ϵ isa Float64 || ϵ isa AbstractVector{<:AbstractFloat}
         edgelengths = SVector{D,T}(ϵ .* v)
-        histsize = ceil.(Int, nextfloat.((maxi .- mini), n_eps) ./ edgelengths)
+        histsize = ceil.(Int, (maxi .- mini) ./ edgelengths)
     elseif ϵ isa Int || ϵ isa Vector{Int}
         edgeslengths_nonadjusted = @. (maxi - mini)/ϵ
         # Just taking nextfloat once here isn't enough for bins to cover data when using

--- a/src/encoding_implementations/rectangular_binning.jl
+++ b/src/encoding_implementations/rectangular_binning.jl
@@ -158,10 +158,12 @@ function FixedRectangularBinning(b::RectangularBinning, x)
     if ϵ isa Float64 || ϵ isa AbstractVector{<:AbstractFloat}
         widths = SVector{D,T}(ϵ .* v)
         # use `nextfloat` to ensure all data are covered!
-        ranges = ntuple(range(mini[i], maxi[i]; step = widths[i]), D)
+        ranges = ntuple(i -> range(mini[i], maxi[i]; step = widths[i]), D)
     elseif ϵ isa Int || ϵ isa Vector{Int}
-        lengths = ϵ .* ones(SVector{D,Int})
-        ranges = ntuple(range(mini[i], maxi[i]; length = lengths[i]), D)
+        # We add one, because the user input specifies the number of bins,
+        # and the number of bins is the range length - 1
+        lengths = ϵ .* ones(SVector{D,Int}) .+ 1
+        ranges = ntuple(i -> range(mini[i], maxi[i]; length = lengths[i]), D)
     else
         error("Invalid ϵ for binning of a dataset")
     end

--- a/src/encoding_implementations/rectangular_binning.jl
+++ b/src/encoding_implementations/rectangular_binning.jl
@@ -87,18 +87,6 @@ function FixedRectangularBinning(r::AbstractRange, D::Int = 1, precise = false)
     FixedRectangularBinning(ntuple(x->r, D), precise)
 end
 
-# Deprecations
-function FixedRectangularBinning(ϵmin::NTuple{D,T}, ϵmax::NTuple{D,T}, N::Int) where {D, T}
-    FixedRectangularBinning(ntuple(x->range(ϵmin[i],ϵmax[i];length=N), D))
-end
-function FixedRectangularBinning(ϵmin::Real, ϵmax::Real, N, D::Int = 1)
-    if N isa Int
-        FixedRectangularBinning(ntuple(x-> range(ϵmin, ϵmax; length = N), D))
-    else
-        FixedRectangularBinning(ntuple(x-> range(ϵmin, ϵmax; step = N), D))
-    end
-end
-
 """
     RectangularBinEncoding <: Encoding
     RectangularBinEncoding(binning::RectangularBinning, x)

--- a/src/encoding_implementations/rectangular_binning.jl
+++ b/src/encoding_implementations/rectangular_binning.jl
@@ -50,8 +50,12 @@ if it is an integer, each dimension is subdivided into that many subintervals.
 Otherwise it is a real, and it is taken as the edge width for each dimension.
 
 Points falling outside the partition do not contribute to probabilities.
-This binning type leads to a well-defined outcome space without knowledge of input data,
-see [`ValueHistogram`](@ref).
+Since bins are always left-closed-right-open `[a, b)`, keep this in mind
+when specifying bin width directly. I.e., if `xmax = 1`,
+a data point with value `1` does not fall into any bins!
+
+`FixedRectangularBinning` leads to a well-defined outcome space without knowledge of input
+data, see [`ValueHistogram`](@ref).
 
 `ϵmin`/`emax` must be `NTuple{D, <:Real}` for input of `D`-dimensional data.
 
@@ -184,7 +188,7 @@ function RectangularBinEncoding(b::FixedRectangularBinning{D, T}; n_eps = 2) whe
     mini = SVector{D, T}(ϵmin)
     maxi = SVector{D, T}(ϵmax)
     if b.subdiv isa Real
-        edgelengths = one(SVector{D, T}) .* b.subdiv
+        edgelengths = ones(SVector{D, T}) .* b.subdiv
         histsize = ceil.(Int, (maxi .- mini) ./ edgelengths)
     elseif b.subdiv isa Int
         N = b.subdiv

--- a/src/encoding_implementations/rectangular_binning.jl
+++ b/src/encoding_implementations/rectangular_binning.jl
@@ -65,23 +65,25 @@ increase of the probability corresponding to the last bin (here `[0.9, 1)`)!
 
 `FixedRectangularBinning` leads to a well-defined outcome space without knowledge of input
 data, see [`ValueHistogram`](@ref).
-
-    FixedRectangularBinning(range::AbstractRange, D::Int = 1, precise = false)
-
-This is a convenience method where each dimension of the binning has the same range
-and the input data are `D` dimensional, which defaults to 1 (timeseries).
 """
 struct FixedRectangularBinning{R<:Tuple} <: AbstractBinning
     ranges::R
     precise::Bool
 end
+
 function FixedRectangularBinning(ranges::R, precise = false) where {R}
     if any(r -> !issorted(r), ranges)
         throw(ArgumentError("All input ranges must be sorted!"))
     end
     return FixedRectangularBinning{R}(ranges, precise)
 end
-# Convenience
+
+"""
+    FixedRectangularBinning(range::AbstractRange, D::Int = 1, precise = false)
+
+This is a convenience method where each dimension of the binning has the same range
+and the input data are `D` dimensional, which defaults to 1 (timeseries).
+"""
 function FixedRectangularBinning(r::AbstractRange, D::Int = 1, precise = false)
     FixedRectangularBinning(ntuple(x->r, D), precise)
 end

--- a/src/encoding_implementations/rectangular_binning.jl
+++ b/src/encoding_implementations/rectangular_binning.jl
@@ -129,7 +129,7 @@ function RectangularBinEncoding(b::FixedRectangularBinning)
     RectangularBinEncoding(ranges, b.precise, histsize, ci, li)
 end
 function RectangularBinEncoding(b::FixedRectangularBinning, x)
-    if length(e.ranges) != dimension(x)
+    if length(b.ranges) != dimension(x)
         throw(ArgumentError("""
         The dimensionality of the `FixedRectangularBinning` and input `x` do not match.
         Got $(e.ranges) and $(dimension(x))."""))
@@ -176,7 +176,9 @@ function encode(e::RectangularBinEncoding, point)
         widths = map(step, ranges)
         mini = map(minimum, ranges)
         # Map a data point to its bin edge (plus one because indexing starts from 1)
-        bin = floor.(Int, (point .- mini) ./ widths) .+ 1
+        # we also use `Tuple` because `point` is `SVector` and the broadcast
+        # below results in  `Vector` if you mix `Tuple` with `SVector`.
+        bin = floor.(Int, (Tuple(point) .- mini) ./ widths) .+ 1
         cartidx = CartesianIndex(bin)
     end
     # We have decided on the arbitrary convention that out of bound points

--- a/src/encoding_implementations/rectangular_binning.jl
+++ b/src/encoding_implementations/rectangular_binning.jl
@@ -7,20 +7,19 @@ abstract type HistogramEncoding <: Encoding end
 ##################################################################
 # Structs and docstrings
 ##################################################################
-# Notice that the binning types are intermediate structs that are not used directly
-# in the source code. Their only purpose is instructions of how to create a
-# `RectangularBinEncoder`. All actual source code functionality of `ValueHistogram`
-# is implemented based on `RectangularBinEncoder`.
+# The binning types are intermediate structs whose only purpose is
+# instructions for initializing the `RectangularBinEncoding`
 
 """
     RectangularBinning(ϵ) <: AbstractBinning
 
 Rectangular box partition of state space using the scheme `ϵ`,
-deducing the coordinates of the grid axis minima from the input data.
-Generally it is preferred to use [`FixedRectangularBinning`](@ref) instead,
-as it has a well defined outcome space without knowledge of input data.
-`RectangularBinning` is re-cast into [`FixedRectangularBinning`](@ref)
-once the data are provided, so see that docstring for info on the bin calculation.
+deducing the histogram extent and bin width from the input data.
+
+`RectangularBinning` is a convenience struct.
+It is re-cast into [`FixedRectangularBinning`](@ref)
+once the data are provided, so see that docstring for info on the bin calculation
+and for the possibility of more precision during the histogram calculation.
 
 Binning instructions are deduced from the type of `ϵ` as follows:
 

--- a/src/encoding_implementations/rectangular_binning.jl
+++ b/src/encoding_implementations/rectangular_binning.jl
@@ -179,14 +179,7 @@ end
 # encode/decode
 ##################################################################
 function encode(e::RectangularBinEncoding, point)
-    ranges = e.ranges
-    if e.precise
-        # Don't know how to make this faster unfurtunately...
-        cartidx = CartesianIndex(map(searchsortedlast, ranges, Tuple(point)))
-    else
-        bin = floor.(Int, (point .- e.mini) ./ e.widths) .+ 1
-        cartidx = CartesianIndex(Tuple(bin))
-    end
+
     # We have decided on the arbitrary convention that out of bound points
     # will get the special symbol `-1`. Erroring doesn't make sense as it is expected
     # that for fixed histograms there may be points outside of them.
@@ -196,6 +189,26 @@ function encode(e::RectangularBinEncoding, point)
         return -1
     end
 end
+
+"""
+    cartesian_bin_index(e::RectangularBinEncoding, point::SVector)
+
+Internal function called by `encode`. Returns the cartesian index of
+the given `point` within the binning encapsulated in `e`.
+"""
+function cartesian_bin_index(e::RectangularBinEncoding, point)
+    ranges = e.ranges
+    if e.precise
+        # Don't know how to make this faster unfurtunately...
+        cartidx = CartesianIndex(map(searchsortedlast, ranges, Tuple(point)))
+    else
+        bin = floor.(Int, (point .- e.mini) ./ e.widths) .+ 1
+        cartidx = CartesianIndex(Tuple(bin))
+    end
+    return cartidx
+end
+
+
 
 function decode(e::RectangularBinEncoding, bin::Int)
     if checkbounds(Bool, e.ci, bin)

--- a/src/encoding_implementations/rectangular_binning.jl
+++ b/src/encoding_implementations/rectangular_binning.jl
@@ -39,14 +39,15 @@ const ValidFixedBinInputs = Union{Number, NTuple}
 
 """
     FixedRectangularBinning <: AbstractBinning
-    FixedRectangularBinning(ϵmin::NTuple, ϵmax::NTuple, z::Union{Real, Int})
+    FixedRectangularBinning(xmin::NTuple, xmax::NTuple, subdiv::Union{Real, Int})
 
 Rectangular box partition of state space where the extent of the grid is explicitly
-specified by `ϵmin` and `emax`, and along each dimension.
+specified by by providing the minium `xmin` and maximum `xmax`
+values along each dimension.
 
 The third argument `subdiv` decides how the grid is subdivided:
-if it is an integer, the grid is subdivided into that many subintervals.
-Otherwise it is a real, and it is taken as the edge width.
+if it is an integer, each dimension is subdivided into that many subintervals.
+Otherwise it is a real, and it is taken as the edge width for each dimension.
 
 Points falling outside the partition do not contribute to probabilities.
 This binning type leads to a well-defined outcome space without knowledge of input data,
@@ -54,7 +55,7 @@ see [`ValueHistogram`](@ref).
 
 `ϵmin`/`emax` must be `NTuple{D, <:Real}` for input of `D`-dimensional data.
 
-    FixedRectangularBinning(ϵmin::Real, ϵmax::Real, subdiv, D::Int = 1)
+    FixedRectangularBinning(xmin::Real, xmax::Real, subdiv, D::Int = 1)
 
 This is a convenience method where each dimension of the binning has the same extent
 and the input data are `D` dimensional, which defaults to 1 (timeseries).

--- a/src/probabilities_estimators/diversity.jl
+++ b/src/probabilities_estimators/diversity.jl
@@ -21,7 +21,8 @@ Diversity probabilities are computed as follows.
 2. Compute ``D = \\{d(\\bf x_t, \\bf x_{t+1}) \\}_{t=1}^{N-mτ-1}``,
     where ``d(\\cdot, \\cdot)`` is the cosine similarity between two `m`-dimensional
     vectors in the embedding.
-3. Divide the interval `[-1, 1]` into `nbins` equally sized subintervals.
+3. Divide the interval `[-1, 1]` into `nbins` equally sized subintervals
+   (including the value `+1`).
 4. Construct a histogram of cosine similarities ``d \\in D`` over those subintervals.
 5. Sum-normalize the histogram to obtain probabilities.
 
@@ -70,5 +71,6 @@ end
 cosine_similarity(xᵢ, xⱼ) = sum(xᵢ .* xⱼ) / (sqrt(sum(xᵢ .^ 2)) * sqrt(sum(xⱼ .^ 2)))
 
 function encoding_for_diversity(nbins::Int)
-    RectangularBinEncoding(FixedRectangularBinning(-1.0, 1.0, nbins))
+    binning = FixedRectangularBinning((range(-1.0, nextfloat(1.0); length = nbins),))
+    return RectangularBinEncoding(binning)
 end

--- a/src/probabilities_estimators/diversity.jl
+++ b/src/probabilities_estimators/diversity.jl
@@ -49,7 +49,7 @@ end
 
 function probabilities_and_outcomes(est::Diversity, x::AbstractVector{T}) where T <: Real
     ds, rbc = similarities_and_binning(est, x)
-    return probabilities_and_outcomes(ValueHistogram(rbc.binning), ds)
+    return probabilities_and_outcomes(rbc, ds)
 end
 
 outcome_space(est::Diversity) = outcome_space(encoding_for_diversity(est.nbins))
@@ -71,6 +71,6 @@ end
 cosine_similarity(xᵢ, xⱼ) = sum(xᵢ .* xⱼ) / (sqrt(sum(xᵢ .^ 2)) * sqrt(sum(xⱼ .^ 2)))
 
 function encoding_for_diversity(nbins::Int)
-    binning = FixedRectangularBinning((range(-1.0, nextfloat(1.0); length = nbins),))
+    binning = FixedRectangularBinning((range(-1.0, nextfloat(1.0); length = nbins+1),))
     return RectangularBinEncoding(binning)
 end

--- a/src/probabilities_estimators/transfer_operator/transfer_operator.jl
+++ b/src/probabilities_estimators/transfer_operator/transfer_operator.jl
@@ -481,5 +481,4 @@ function probabilities_and_outcomes(est::TransferOperator, x::Array_or_Dataset)
     return probs, outcomes
 end
 
-outcome_space(x, est::TransferOperator) = outcome_space(x, est.binning)
-total_outcomes(x, est::TransferOperator) = total_outcomes(x, est.binning)
+outcome_space(est::TransferOperator, x) = outcome_space(est.encoder, x)

--- a/src/probabilities_estimators/transfer_operator/transfer_operator.jl
+++ b/src/probabilities_estimators/transfer_operator/transfer_operator.jl
@@ -468,8 +468,7 @@ function transfermatrix(iv::InvariantMeasure)
 end
 
 function probabilities_and_outcomes(est::TransferOperator, x::Array_or_Dataset)
-    encoder = RectangularBinEncoding(est.binning, x)
-    to = transferoperator(x, encoder.binning)
+    to = transferoperator(x, est.binning)
     probs = invariantmeasure(to).ρ
 
     # Note: bins are *not* sorted. They occur in the order of first appearance, according

--- a/src/probabilities_estimators/transfer_operator/transfer_operator.jl
+++ b/src/probabilities_estimators/transfer_operator/transfer_operator.jl
@@ -439,10 +439,6 @@ function invariantmeasure(to::TransferOperatorApproximationRectangular;
         distribution = distribution ./ colsum_distribution
     end
 
-    # Find partition elements with strictly positive measure.
-    δ = tolerance/size(to.transfermatrix, 1)
-    inds_nonzero = findall(distribution .> δ)
-
     # Extract the elements of the invariant measure corresponding to these indices
     return InvariantMeasure(to, Probabilities(distribution))
 end

--- a/src/probabilities_estimators/transfer_operator/transfer_operator.jl
+++ b/src/probabilities_estimators/transfer_operator/transfer_operator.jl
@@ -285,12 +285,10 @@ function transferoperator(pts::AbstractDataset{D, T},
             # To which boxes do each of the visitors to bᵢ jump in the next
             # time step?
             target_bins = visits_whichbin[timeindices_visiting_pts .+ 1]
-            unique_target_bins = unique(target_bins)
 
             # Count how many points jump from the i-th bin to each of
             # the unique target bins, and use that to calculate the transition
             # probability from bᵢ to bⱼ.
-            #for j in 1:length(unique_target_bins)
             for (j, bᵤ) in enumerate(unique(target_bins))
                 n_transitions_i_to_j = sum(target_bins .== bᵤ)
 

--- a/src/probabilities_estimators/transfer_operator/transfer_operator.jl
+++ b/src/probabilities_estimators/transfer_operator/transfer_operator.jl
@@ -117,8 +117,7 @@ end
 # for datasets of >100 000+ points
 function inds_in_terms_of_unique_sorted(x) # assumes sorted
     @assert issorted(x)
-    U = unique(x)
-    N, Nu = length(x), length(U)
+    N = length(x)
     prev = view(x, 1)
     inds = zeros(Int, N)
     uidx = 1
@@ -236,10 +235,8 @@ function transferoperator(pts::AbstractDataset{D, T},
     n_visitsᵢ::Int = 0
 
     if boundary_condition == :circular
-        #warn("Using circular boundary condition")
         append!(visits_whichbin, [1])
     elseif boundary_condition == :random
-        #warn("Using random circular boundary condition")
         append!(visits_whichbin, [rand(1:length(visits_whichbin))])
     else
         error("Boundary condition $(boundary_condition) not implemented")

--- a/src/probabilities_estimators/transfer_operator/transfer_operator.jl
+++ b/src/probabilities_estimators/transfer_operator/transfer_operator.jl
@@ -179,17 +179,6 @@ struct TransferOperatorApproximationRectangular{
     visitors::Vector{Vector{Int}}
 end
 
-function transferoperatorencoder(
-    binning::Union{FixedRectangularBinning, RectangularBinning}, x::AbstractDataset
-)
-    if binning isa FixedRectangularBinning
-        return RectangularBinEncoding(binning)
-    elseif binning isa RectangularBinning
-        return RectangularBinEncoding(binning, x)
-    else
-        throw(ArgumentError("Binning $(typeof(binning)) not supported for transfer operator"))
-    end
-end
 """
     transferoperator(pts::AbstractDataset,
         binning::RectangularBinning) → TransferOperatorApproximationRectangular
@@ -217,7 +206,7 @@ function transferoperator(pts::AbstractDataset{D, T},
         boundary_condition = :circular) where {D, T<:Real}
 
     L = length(pts)
-    encoder = transferoperatorencoder(binning, pts)
+    encoder = RectangularBinEncoding(binning, pts)
 
     # The L points visits a total of L bins, which are the following bins (referenced
     # here as cartesian coordinates, not absolute bins):
@@ -479,7 +468,7 @@ function transfermatrix(iv::InvariantMeasure)
 end
 
 function probabilities_and_outcomes(est::TransferOperator, x::Array_or_Dataset)
-    encoder = transferoperatorencoder(est.binning, x)
+    encoder = RectangularBinEncoding(est.binning, x)
     to = transferoperator(x, encoder.binning)
     probs = invariantmeasure(to).ρ
 

--- a/src/probabilities_estimators/value_histogram.jl
+++ b/src/probabilities_estimators/value_histogram.jl
@@ -61,6 +61,9 @@ end
 
 function probabilities_and_outcomes(est::ValueHistogram, x)
     encoding = RectangularBinEncoding(est.binning, x)
+    return probabilities_and_outcomes(encoding, x)
+end
+function probabilities_and_outcomes(encoding::RectangularBinEncoding, x)
     probs, bins = fasthist(encoding, x) # bins are integers here
     unique!(bins) # `bins` is already sorted from `fasthist!`
     # Here we transfor the cartesian coordinate based bins into data unit bins:

--- a/src/probabilities_estimators/value_histogram.jl
+++ b/src/probabilities_estimators/value_histogram.jl
@@ -30,7 +30,10 @@ The outcome space for `ValueHistogram` is the unique bins constructed
 from `b`. Each bin is identified by its left (lowest-value) corner,
 because bins are always left-closed-right-open intervals `[a, b)`.
 The bins are in data units, not integer (cartesian indices units), and
-are returned as `SVector`s.
+are returned as `Tuple`s. For convenience, [`outcome_space`](@ref)
+returns the outcomes in the same array format as the histogram
+(e.g., `Matrix` for 2D input).
+
 For [`FixedRectangularBinning`](@ref) the [`outcome_space`](@ref) is well-defined from the
 binning, but for [`RectangularBinning`](@ref) input `x` is needed as well.
 """

--- a/src/probabilities_estimators/value_histogram.jl
+++ b/src/probabilities_estimators/value_histogram.jl
@@ -27,11 +27,12 @@ and initializes this binning directly.
 ## Outcomes
 
 The outcome space for `ValueHistogram` is the unique bins constructed
-from `b`. Each bin is identified by its left (lowest-value) corner.
+from `b`. Each bin is identified by its left (lowest-value) corner,
+because bins are always left-closed-right-open intervals `[a, b)`.
 The bins are in data units, not integer (cartesian indices units), and
 are returned as `SVector`s.
-For [`FixedRectangularBinning`](@ref) this is well-defined from the binning, but for
-[`RectangularBinning`](@ref) input `x` is needed for a well-defined [`outcome_space`](@ref).
+For [`FixedRectangularBinning`](@ref) the [`outcome_space`](@ref) is well-defined from the
+binning, but for [`RectangularBinning`](@ref) input `x` is needed as well.
 """
 struct ValueHistogram{B<:AbstractBinning} <: ProbabilitiesEstimator
     binning::B
@@ -63,3 +64,7 @@ function probabilities_and_outcomes(est::ValueHistogram, x)
 end
 
 outcome_space(est::ValueHistogram, x) = outcome_space(RectangularBinEncoding(est.binning, x))
+
+function outcome_space(est::ValueHistogram{<:FixedRectangularBinning})
+    return outcome_space(RectangularBinEncoding(est.binning))
+end

--- a/src/probabilities_estimators/value_histogram.jl
+++ b/src/probabilities_estimators/value_histogram.jl
@@ -30,8 +30,10 @@ The outcome space for `ValueHistogram` is the unique bins constructed
 from `b`. Each bin is identified by its left (lowest-value) corner,
 because bins are always left-closed-right-open intervals `[a, b)`.
 The bins are in data units, not integer (cartesian indices units), and
-are returned as `Tuple`s. For convenience, [`outcome_space`](@ref)
-returns the outcomes in the same array format as the histogram
+are returned as `SVector`s, i.e., same type as input data.
+
+For convenience, [`outcome_space`](@ref)
+returns the outcomes in the same array format as the underlying binning
 (e.g., `Matrix` for 2D input).
 
 For [`FixedRectangularBinning`](@ref) the [`outcome_space`](@ref) is well-defined from the

--- a/test/probabilities/estimators/transfer_operator.jl
+++ b/test/probabilities/estimators/transfer_operator.jl
@@ -9,7 +9,7 @@ binnings = [
     RectangularBinning(0.2),
     RectangularBinning([2, 3]),
     RectangularBinning([0.2, 0.3]),
-    FixedRectangularBinning(0, 1, 5, 2)
+    FixedRectangularBinning(rage(0, 1; length = 5), 2)
 ]
 
 # There's not easy way of constructing an analytical example for the resulting

--- a/test/probabilities/estimators/transfer_operator.jl
+++ b/test/probabilities/estimators/transfer_operator.jl
@@ -9,7 +9,7 @@ binnings = [
     RectangularBinning(0.2),
     RectangularBinning([2, 3]),
     RectangularBinning([0.2, 0.3]),
-    FixedRectangularBinning(rage(0, 1; length = 5), 2)
+    FixedRectangularBinning(range(0, 1; length = 5), 2)
 ]
 
 # There's not easy way of constructing an analytical example for the resulting

--- a/test/probabilities/estimators/value_histogram.jl
+++ b/test/probabilities/estimators/value_histogram.jl
@@ -2,29 +2,43 @@ using ComplexityMeasures
 using Test
 using Random
 
-@testset "Rectangular binning" begin
+@testset "Standard ranges binning" begin
 
     x = Dataset(rand(Random.MersenneTwister(1234), 100_000, 2))
     push!(x, SVector(0, 0)) # ensure both 0 and 1 have values in, exactly.
     push!(x, SVector(1, 1))
-    # All these binnings should give approximately same probabilities
-    n = 10 # boxes cover 0 - 1 in steps of slightly more than 0.1
-    ε = nextfloat(0.1, 2) # this guarantees that we get the same as the `n` above!
 
+    # All these binnings give exactly the same ranges because of the 0-1 values
+    # The value 1 is always included, due to the call of `nextfloat` when making
+    # ranges for the `FixedRectangularBinning`
+    n = 10
+    ε = nextfloat(0.1)
+
+    # All following binnings are equivalent
     binnings = [
-        n,
-        ε,
         RectangularBinning(n),
+        RectangularBinning(n, true),
         RectangularBinning(ε),
         RectangularBinning([n, n]),
-        RectangularBinning([ε, ε])
+        RectangularBinning([ε, ε]),
+        FixedRectangularBinning(range(0, nextfloat(1.0); length = n+1), 2),
+        FixedRectangularBinning(range(0, nextfloat(1.0); length = n+1), 2, true),
+        FixedRectangularBinning(
+            (range(0, nextfloat(1.0); step = ε), range(0, nextfloat(1.0); step = ε))
+        ),
+
     ]
 
     for bin in binnings
-        @testset "bin isa $(typeof(bin))" begin
+        @testset "bin isa $(nameof(typeof(bin)))" begin
             est = ValueHistogram(bin)
+            out = outcome_space(est, x)
+            @test length(out) == n^2
+
             p = probabilities(est, x)
+            # all bins are covered due to random data
             @test length(p) == 100
+            # ensure uniform coverage since input is uniformly random
             @test all(e -> 0.009 ≤ e ≤ 0.011, p)
 
             p2, o = probabilities_and_outcomes(est, x)
@@ -34,14 +48,16 @@ using Random
             @test all(x -> x < 1, maximum(o))
             o2 = outcomes(est, x)
             @test o2 == o
-        end
-    end
 
-    @testset "Check rogue 1s" begin
-        b = RectangularBinning(0.1) # no `nextfloat` here, so the rogue (1, 1) is in extra bin!
-        p = probabilities(ValueHistogram(b), x)
-        @test length(p) == 100 + 1
-        @test p[end] ≈ 1/100_000 atol = 1e-5
+            ospace = outcome_space(est, x)
+            @test ospace isa Matrix{SVector{2, Float64}}
+            @test size(ospace) == (n,n)
+            @test SVector(0.0, 0.0) ∈ ospace
+
+            # ensure 1 is included, and must also be in the last bin
+            rbe = RectangularBinEncoding(bin, x)
+            @test encode(rbe, SVector(1.0, 1.0)) == n^2
+        end
     end
 
     @testset "vector" begin
@@ -56,51 +72,42 @@ using Random
         end
     end
 
-    # An extra bin might appear due to roundoff error after using nextfloat when
-    # constructing `RectangularBinEncoding`s.
-    # The following tests ensure with *some* certainty that this does not occur.
-    @testset "Rogue extra bins" begin
-        # Concrete examples where a rogue extra bin has appeared.
-        x1 = [0.5213236385155418, 0.03516318860292644, 0.5437726723245310, 0.52598710966469610, 0.34199879802511246, 0.6017129426606275, 0.6972844365031351, 0.89163995617220900, 0.39009862510518045, 0.06296038912844315, 0.9897176284081909, 0.7935001082966890, 0.890198448900077700, 0.11762640519877565, 0.7849413168095061, 0.13768932585886573, 0.50869900547793430, 0.18042178201388548, 0.28507312391861270, 0.96480406570924970]
-        x2 = [0.4125754262679051, 0.52844411982339560, 0.4535277505543355, 0.25502420827802674, 0.77862522996085940, 0.6081939026664078, 0.2628674795466387, 0.18846258495465185, 0.93320375283233840, 0.40093871561247874, 0.8032730760974603, 0.3531608285217499, 0.018436525139752136, 0.55541857934068420, 0.9907521337888632, 0.15382361136212420, 0.01774321666660561, 0.67569337507728300, 0.06130971689608822, 0.31417161558476836]
-        N = 10
-        b = RectangularBinning(N)
-        rb1 = RectangularBinEncoding(b, x1; n_eps = 1)
-        rb2 = RectangularBinEncoding(b, x1; n_eps = 2)
-        @test encode(rb1, maximum(x1)) == -1 # shouldn't occur, but does when tolerance is too low
-        @test encode(rb2, maximum(x1)) == 10
-
-        rb1 = RectangularBinEncoding(b, x2; n_eps = 1)
-        rb2 = RectangularBinEncoding(b, x2; n_eps = 2)
-        @test encode(rb1, maximum(x2)) == -1 # shouldn't occur, but does when tolerance is too low
-        @test encode(rb2, maximum(x2)) == 10
+    @testset "convenience" begin
+        @test ValueHistogram(n) == ValueHistogram(RectangularBinning(n))
+        @test ValueHistogram(ε) == ValueHistogram(RectangularBinning(ε))
     end
 
 end
 
+@testset "Encodings, edge cases" begin
+    # Encoding has been practically tested fully in the codes above.
+    # here we just ensure the API works as expected and edge cases also
+    # work as expected.
+    # Concrete examples where a rogue extra bin has appeared.
+    x1 = [0.5213236385155418, 0.03516318860292644, 0.5437726723245310, 0.52598710966469610, 0.34199879802511246, 0.6017129426606275, 0.6972844365031351, 0.89163995617220900, 0.39009862510518045, 0.06296038912844315, 0.9897176284081909, 0.7935001082966890, 0.890198448900077700, 0.11762640519877565, 0.7849413168095061, 0.13768932585886573, 0.50869900547793430, 0.18042178201388548, 0.28507312391861270, 0.96480406570924970]
+    N = 10
 
-@testset "Fixed Rectangular binning" begin
+    b1 = RectangularBinning(N)
+    rb1 = RectangularBinEncoding(RectangularBinning(N, false), x1)
+    rb2 = RectangularBinEncoding(RectangularBinning(N, true), x1)
 
-    x = Dataset(rand(Random.MersenneTwister(1234), 100_000, 2))
-    push!(x, SVector(0, 0)) # ensure both 0 and 1 have values in, exactly.
-    push!(x, SVector(1, 1))
-    # All these binnings should give approximately same probabilities
-    n = 10 # boxes cover 0 - 1 in steps of slightly more than 0.1
-    ε = nextfloat(0.1, 2) # this guarantees that we get the same as the `n` above!
+    # With low accuracy we get this rounding error
+    @test encode(rb1, maximum(x1)) == -1
+    @test encode(rb2, maximum(x1)) == 10
 
-    bin = FixedRectangularBinning(0.0, 1.0, n, 2)
+    x2 = [0.4125754262679051, 0.52844411982339560, 0.4535277505543355, 0.25502420827802674, 0.77862522996085940, 0.6081939026664078, 0.2628674795466387, 0.18846258495465185, 0.93320375283233840, 0.40093871561247874, 0.8032730760974603, 0.3531608285217499, 0.018436525139752136, 0.55541857934068420, 0.9907521337888632, 0.15382361136212420, 0.01774321666660561, 0.67569337507728300, 0.06130971689608822, 0.31417161558476836]
+    rb1 = RectangularBinEncoding(RectangularBinning(N, false), x2)
+    rb2 = RectangularBinEncoding(RectangularBinning(N, true), x2)
+    @test encode(rb1, maximum(x2)) == -1
+    @test encode(rb2, maximum(x2)) == 10
 
-    est = ValueHistogram(bin)
-    p = probabilities(est, x)
-    @test length(p) == 100
-    @test all(e -> 0.009 ≤ e ≤ 0.011, p)
-
-    p2, o = probabilities_and_outcomes(est, x)
-    @test p2 == p
-    @test o isa Vector{SVector{2, Float64}}
-    @test length(o) == length(p)
-    @test all(x -> x < 1, maximum(o))
-    o2 = outcomes(est, x)
-    @test o2 == o
-
+    # and a final analytic test with decode
+    bin = FixedRectangularBinning(range(0, 1.0; length = 11), 2, true)
+    rbc = RectangularBinEncoding(bin)
+    @test encode(rbc, SVector(0.0, 0.0)) == 1
+    @test encode(rbc, SVector(1.0, 1.0)) == -1
+    @test decode(rbc, 1) == SVector(0.0, 0.0)
+    @test decode(rbc, 100) == SVector(0.9, 0.9)
 end
+
+

--- a/test/probabilities/estimators/value_histogram.jl
+++ b/test/probabilities/estimators/value_histogram.jl
@@ -12,9 +12,10 @@ using Random
     # The value 1 is always included, due to the call of `nextfloat` when making
     # ranges for the `FixedRectangularBinning`
     n = 10
-    ε = nextfloat(0.1)
+    ε = nextfloat(0.1) # when dividing 0-nextfloat(1) into 10, you get this width
 
     # All following binnings are equivalent
+    # (`nextfloat` is necessary in Fixed, due to the promise given in the regular)
     binnings = [
         RectangularBinning(n),
         RectangularBinning(n, true),
@@ -26,8 +27,13 @@ using Random
         FixedRectangularBinning(
             (range(0, nextfloat(1.0); step = ε), range(0, nextfloat(1.0); step = ε))
         ),
-
     ]
+    # all reduce to these ranges (due to demanding ALL data to be in
+    # the histogram, i.e., also the `SVector(1,1)`)
+    casted_ranges = (
+        0.0:0.10000000000000002:1.0000000000000002,
+        0.0:0.10000000000000002:1.0000000000000002
+    )
 
     for bin in binnings
         @testset "bin isa $(nameof(typeof(bin)))" begin
@@ -57,6 +63,8 @@ using Random
             # ensure 1 is included, and must also be in the last bin
             rbe = RectangularBinEncoding(bin, x)
             @test encode(rbe, SVector(1.0, 1.0)) == n^2
+
+            @test rbe.ranges == casted_ranges
         end
     end
 

--- a/test/probabilities/estimators/value_histogram.jl
+++ b/test/probabilities/estimators/value_histogram.jl
@@ -118,4 +118,18 @@ end
     @test decode(rbc, 100) == SVector(0.9, 0.9)
 end
 
+@testset "All points covered" begin
+    x = Dataset(rand(100, 2))
+    binnings = [
+        RectangularBinning(5, true),
+        RectangularBinning(0.2, true),
+        RectangularBinning([2, 4], true),
+        RectangularBinning([0.5, 0.25], true),
+    ]
 
+    for bin in binnings
+        rbe = RectangularBinEncoding(bin, x)
+        visited_bins = map(pᵢ -> encode(rbe, pᵢ), x)
+        @test -1 ∉ visited_bins
+    end
+end

--- a/test/probabilities/estimators/value_histogram.jl
+++ b/test/probabilities/estimators/value_histogram.jl
@@ -88,7 +88,7 @@ end
     n = 10 # boxes cover 0 - 1 in steps of slightly more than 0.1
     ε = nextfloat(0.1, 2) # this guarantees that we get the same as the `n` above!
 
-    bin = FixedRectangularBinning(0, 1, n, 2)
+    bin = FixedRectangularBinning(0.0, 1.0, n, 2)
 
     est = ValueHistogram(bin)
     p = probabilities(est, x)


### PR DESCRIPTION
Our binning code was really bad when it came down to real world usage. When preparing the workshop, showing the ouputs of value histogram was alwas unintuitive. This thing we do with `n_eps` and `nextfloat` always leads to completely random and unintuitive numbers for the histogram edges. it also is very hard to get "the expected histogram" for different distribtions, hence computing the KL divergence. Furthermore, it is fundamentally inaccurate.

A much better approach is to give up trying to "hack up" some accuracy ourselves, and instead take advantage of Julia's base `range` system that operates using `TwicePrecision` to always keep range step sizes what the user expects without dealing with floating point precision. So that range `0:0.1:1` has exactly 0.1 step and exactly length of 11.

I have fully re-written the internals of rectangular binnings to utilize ranges. This has lead to many, many benefits:

1. `RectangularBinning` is an intermediate struct that gets cast into a `FixedRectangularBinning`. This reduces a lot the code.
2. All the hacky stuff we do with `n_eps` have been completely removed. They were never accurate to begin with; they just changed the histogram sizes but they were just as inaccurate. To be accurate you need double precision.
3. `FixedRectangularBinning` now takes in standard julia `range`s as input. One `range` for each dimension, with convenience constructors. **This allows us to utilize Julia's internal double precision system without any hacky stuff**. This **also means taht the outcome space has nice, simple edges and bin widths, which is what a user would like.**.
4. Binnings have a `precise` option: if true, they use `searchsortedlast`, which uses internally the double precision, to map data to correct bin according to ranges. If `false` they use our standard division with the bin width.

To give an example of how much of achange this does, here we go:
```julia
    x = Dataset(rand(Random.MersenneTwister(1234), 100_000, 2))
    push!(x, SVector(0, 0)) # ensure both 0 and 1 have values in, exactly.
    push!(x, SVector(1, 1))

    bin = FixedRectangularBinning(0:0.1:1, 2)
    est = ValueHistogram(bin)
    out = outcome_space(est, x)
# equivalent with 
outcome_space(bin)
```
```
julia> out
10×10 Matrix{SVector{2, Float64}}:
 [0.0, 0.0]  [0.0, 0.1]  …  [0.0, 0.9]
 [0.1, 0.0]  [0.1, 0.1]     [0.1, 0.9]
 [0.2, 0.0]  [0.2, 0.1]     [0.2, 0.9]
 [0.3, 0.0]  [0.3, 0.1]     [0.3, 0.9]
 [0.4, 0.0]  [0.4, 0.1]     [0.4, 0.9]
 [0.5, 0.0]  [0.5, 0.1]  …  [0.5, 0.9]
 [0.6, 0.0]  [0.6, 0.1]     [0.6, 0.9]
 [0.7, 0.0]  [0.7, 0.1]     [0.7, 0.9]
 [0.8, 0.0]  [0.8, 0.1]     [0.8, 0.9]
 [0.9, 0.0]  [0.9, 0.1]     [0.9, 0.9]
```

