### PR TITLE
Fix log units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,23 @@
 
 Changelog is kept with respect to version 0.11 of Entropies.jl. From version v2.0 onwards, this package has been renamed to ComplexityMeasures.jl.
 
+## 2.6
+
+- Fixed differential entropy "unit" bug caused by erroneous conversion between logarithm
+    bases and introduced the `convert_logunit` function to convert between entropies
+    computed with different logarithm bases.
+
 ## 2.5
+
 - Moved to StateSpaceSets.jl v1 (only renames of `Dataset` to `StateSpaceSet`).
 
 ## 2.4
+
 - Rectangular binnings have been reformed to operate based on ranges. This leads to much more intuitive bin sizes and edges. For `RectangularBinning` nothing changes, while for `FixedRectangularBinning` the ranges should be given explicitly. Backwards compatible deprecations have been added.
 - This also allows for a new `precise` option that utilizes Base Julia `TwinPrecision` to make more accurate mapping of points to bins at the cost of performance.
 
 ## 2.3
+
 - Like differential entropies, discrete entropies now also have their own estimator type.
 - The approach of giving both an entropy definition, and an entropy estimator to `entropy` has been dropped. Now the entropy estimators know what definitions they are applied for. This change is a deprecation, i.e., backwards compatible.
 - Added `MLEntropy` discrete entropy estimator.

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ComplexityMeasures"
 uuid = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/ComplexityMeasures.jl.git"
-version = "2.5.1"
+version = "2.6.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/docs/src/entropies.md
+++ b/docs/src/entropies.md
@@ -84,9 +84,3 @@ AlizadehArghami
 Ebrahimi
 Correa
 ```
-
-## Convenience
-
-```@docs
-convert_logunit
-```

--- a/docs/src/entropies.md
+++ b/docs/src/entropies.md
@@ -84,3 +84,9 @@ AlizadehArghami
 Ebrahimi
 Correa
 ```
+
+## Convenience
+
+```@docs
+convert_logunit
+```

--- a/src/entropies_estimators/nearest_neighbors/Gao.jl
+++ b/src/entropies_estimators/nearest_neighbors/Gao.jl
@@ -55,10 +55,12 @@ function entropy(est::Gao, x::AbstractStateSpaceSet{D}) where D
     tree = KDTree(x, Euclidean())
     idxs, ds = bulksearch(tree, x, NeighborNumber(k), Theiler(w))
 
-    h = -(1 / N) * sum(log(f * 1 / last(dᵢ)^D) for dᵢ in ds) # in nats
+    # The estimated entropy has "unit" [nats]
+    h = -(1 / N) * sum(log(f * 1 / last(dᵢ)^D) for dᵢ in ds)
     if est.corrected
         correction = digamma(k) - log(k)
         h -= correction
     end
-    return h / log(est.base, ℯ) # convert to target unit *after* correction
+
+    return convert_logunit(h, ℯ, est.base) # convert to target unit *after* correction
 end

--- a/src/entropies_estimators/nearest_neighbors/Goria.jl
+++ b/src/entropies_estimators/nearest_neighbors/Goria.jl
@@ -57,11 +57,11 @@ function entropy(est::Goria, x::AbstractStateSpaceSet{D}) where D
 
     tree = KDTree(x, Euclidean())
     ds = last.(bulksearch(tree, x, NeighborNumber(k), Theiler(w))[2])
+    # The estimated entropy has "unit" [nats]
     h = D * log(prod(ds .^ (1 / N))) +
           log(N - 1) +
           log(c1(D)) -
           digamma(k)
-
-    return h / log(est.base, ℯ)
+    return convert_logunit(h, ℯ, est.base)
 end
 c1(D::Int) = (2π^(D/2)) / (D* gamma(D/2))

--- a/src/entropies_estimators/nearest_neighbors/KozachenkoLeonenko.jl
+++ b/src/entropies_estimators/nearest_neighbors/KozachenkoLeonenko.jl
@@ -51,5 +51,5 @@ function entropy(est::KozachenkoLeonenko, x::AbstractStateSpaceSet{D}) where {D}
         log(MathConstants.e, ball_volume(D)) +
         MathConstants.eulergamma +
         log(MathConstants.e, N - 1)
-    return h / log(est.base, MathConstants.e) # Convert to target unit
+    return convert_logunit(h, ℯ, est.base)
 end

--- a/src/entropies_estimators/nearest_neighbors/Kraskov.jl
+++ b/src/entropies_estimators/nearest_neighbors/Kraskov.jl
@@ -43,5 +43,5 @@ function entropy(est::Kraskov, x::AbstractStateSpaceSet{D}) where {D}
     h = -digamma(k) + digamma(N) +
         log(MathConstants.e, ball_volume(D)) +
         D/N*sum(log.(MathConstants.e, ρs))
-    return h / log(est.base, MathConstants.e) # Convert to target unit
+    return convert_logunit(h, ℯ, est.base)
 end

--- a/src/entropies_estimators/nearest_neighbors/Lord.jl
+++ b/src/entropies_estimators/nearest_neighbors/Lord.jl
@@ -127,9 +127,10 @@ function entropy(est::Lord, x::AbstractStateSpaceSet{D}) where {D}
             h += log(kᵢ * γ / (f * ϵᵢ^D * prod(Σ ./ σ₁)) )
         end
     end
+    # The estimated entropy has "unit" [nats]
     h = - h / N
 
-    return h / log(est.base, ℯ)
+    return convert_logunit(h, ℯ, est.base)
 end
 
 # This is zero-allocating.

--- a/src/entropies_estimators/nearest_neighbors/Zhu.jl
+++ b/src/entropies_estimators/nearest_neighbors/Zhu.jl
@@ -42,8 +42,9 @@ function entropy(est::Zhu, x::AbstractStateSpaceSet{D, T}) where {D, T}
     N = length(x)
     tree = KDTree(x, Euclidean())
     nn_idxs = bulkisearch(tree, x, NeighborNumber(k), Theiler(w))
+    # The estimated entropy has "unit" [nats]
     h = digamma(N) + mean_logvolumes(x, nn_idxs, N) - digamma(k) + (D - 1) / k
-    return h / log(est.base, MathConstants.e)
+    return convert_logunit(h, ℯ, est.base)
 end
 
 function mean_logvolumes(x, nn_idxs, N::Int)

--- a/src/entropies_estimators/nearest_neighbors/ZhuSingh.jl
+++ b/src/entropies_estimators/nearest_neighbors/ZhuSingh.jl
@@ -57,8 +57,9 @@ function entropy(est::ZhuSingh, x::AbstractStateSpaceSet{D, T}) where {D, T}
     tree = KDTree(x, Euclidean())
     nn_idxs = bulkisearch(tree, x, NeighborNumber(k), Theiler(w))
     mean_logvol, mean_digammaξ = mean_logvolumes_and_digamma(x, nn_idxs, N, k)
+    # The estimated entropy has "unit" [nats]
     h = digamma(N) + mean_logvol - mean_digammaξ
-    return h / log(est.base, MathConstants.e)
+    return convert_logunit(h, ℯ, est.base)
 end
 
 function mean_logvolumes_and_digamma(x, nn_idxs, N::Int, k::Int)

--- a/src/entropies_estimators/order_statistics/AlizadehArghami.jl
+++ b/src/entropies_estimators/order_statistics/AlizadehArghami.jl
@@ -57,6 +57,7 @@ function entropy(est::AlizadehArghami, x::AbstractVector{<:Real})
     (; m) = est
     n = length(x)
     m < floor(Int, n / 2) || throw(ArgumentError("Need m < length(x)/2."))
+    # The estimated entropy has "unit" [nats]
     h = entropy(Vasicek(; m, base = MathConstants.e), x) + (2 / n)*(m * log(2))
-    return h / log(est.base, MathConstants.e)
+    return convert_logunit(h, ℯ, est.base)
 end

--- a/src/entropies_estimators/order_statistics/Correa.jl
+++ b/src/entropies_estimators/order_statistics/Correa.jl
@@ -80,7 +80,10 @@ function entropy(est::Correa, x::AbstractVector{<:Real})
         den *= n
         HCₘₙ += log(num / den)
     end
-    return (-HCₘₙ / n) / log(est.base, ℯ)
+    # The estimated entropy has "unit" [nats]
+    h = -HCₘₙ / n
+    return convert_logunit(h, ℯ, est.base)
+
 end
 
 function local_scaled_mean(ex, i::Int, m::Int, n::Int = length(x))

--- a/src/entropies_estimators/order_statistics/Ebrahimi.jl
+++ b/src/entropies_estimators/order_statistics/Ebrahimi.jl
@@ -87,5 +87,8 @@ function entropy(est::Ebrahimi, x::AbstractVector{<:Real})
         dprev = ith_order_statistic(ex, i - m, n)
         HVₘₙ += log(f * (dnext - dprev))
     end
-    return (HVₘₙ / n) / log(est.base, ℯ)
+
+    # The estimated entropy has "unit" [nats]
+    h = HVₘₙ / n
+    return convert_logunit(h, ℯ, est.base)
 end

--- a/src/entropies_estimators/order_statistics/Vasicek.jl
+++ b/src/entropies_estimators/order_statistics/Vasicek.jl
@@ -73,5 +73,8 @@ function entropy(est::Vasicek, x::AbstractVector{T}) where {T<:Real}
         dprev = ith_order_statistic(ex, i - m, n)
         HVₘₙ += log(f * (dnext - dprev))
     end
-    return (HVₘₙ / n) / log(est.base, ℯ)
+
+    # The estimated entropy has "unit" [nats]
+    h = HVₘₙ / n
+    return convert_logunit(h, ℯ, est.base)
 end

--- a/src/entropy.jl
+++ b/src/entropy.jl
@@ -1,7 +1,7 @@
 export EntropyDefinition
 export MLEntropy, DiscEntropyEst, DiscreteEntropyEstimator
 export DiffEntropyEst, DifferentialEntropyEstimator
-export entropy, entropy_maximum, entropy_normalized
+export entropy, entropy_maximum, entropy_normalized, convert_logunit
 
 """
     EntropyDefinition
@@ -244,4 +244,14 @@ function log_with_base(base)
     else
         x -> log(base, x)
     end
+end
+
+"""
+    convert_logunit(h_a::Real, , to) → h_b
+
+Convert a number `h_a` computed with logarithms to base `a` to an entropy `h_b` computed
+with logarithms to base `b`. This can be used to convert the "unit" of an entropy.
+"""
+function convert_logunit(h::Real, base_from, base_to)
+    h / log(base_from, base_to)
 end

--- a/test/entropies/estimators/alizadeharghami.jl
+++ b/test/entropies/estimators/alizadeharghami.jl
@@ -3,11 +3,11 @@ using ComplexityMeasures, Test
 # Check if the estimator converge to true values for some distributions with
 # analytically derivable entropy.
 # -------------------------------------------------------------------------------------
-# EntropyDefinition to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
+# Entropy to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
 U = 0.00
-# EntropyDefinition with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
+# Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
 N = round(0.5*log(2π) + 0.5, digits = 2)
-N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
+N_base3 = ComplexityMeasures.convert_logunit(N, ℯ, 3)
 
 npts = 1000000
 ea = entropy(AlizadehArghami(m = 100), rand(npts))

--- a/test/entropies/estimators/correa.jl
+++ b/test/entropies/estimators/correa.jl
@@ -3,11 +3,11 @@ using ComplexityMeasures, Test
 # Check if the estimator converge to true values for some distributions with
 # analytically derivable entropy.
 # -------------------------------------------------------------------------------------
-# EntropyDefinition to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
+# Entropy to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
 U = 0.00
-# EntropyDefinition with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
+# Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
 N = round(0.5*log(2π) + 0.5, digits = 2)
-N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
+N_base3 = ComplexityMeasures.convert_logunit(N, ℯ, 3)
 
 npts = 1000000
 ea = entropy(Correa(m = 100), rand(npts))

--- a/test/entropies/estimators/ebrahimi.jl
+++ b/test/entropies/estimators/ebrahimi.jl
@@ -3,11 +3,11 @@ using ComplexityMeasures, Test
 # Check if the estimator converge to true values for some distributions with
 # analytically derivable entropy.
 # -------------------------------------------------------------------------------------
-# EntropyDefinition to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
+# Entropy to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
 U = 0.00
-# EntropyDefinition with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
+# Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
 N = round(0.5*log(2π) + 0.5, digits = 2)
-N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
+N_base3 = ComplexityMeasures.convert_logunit(N, ℯ, 3)
 
 npts = 1000000
 ea = entropy(Ebrahimi(m = 100), rand(npts))

--- a/test/entropies/estimators/estimators.jl
+++ b/test/entropies/estimators/estimators.jl
@@ -1,3 +1,14 @@
+# Ensure unit conversion is correct
+h_nats = 1.42
+h_bits = convert_logunit(h_nats, ℯ, 2)
+h_trits = convert_logunit(h_bits, 2, 3)
+h_bans = convert_logunit(h_trits, 3, 10)
+@test round(h_bits, digits = 3) ≈ 2.049
+@test round(h_trits, digits = 3) ≈ 1.293
+@test round(h_bans, digits = 3) ≈ 0.617
+# A cycle of conversions returns to the same value.
+@test h_nats ≈ convert_logunit(h_bans, 10, ℯ)
+
 testfile("kozachenkoleonenko.jl")
 testfile("kraskov.jl")
 testfile("zhu.jl")

--- a/test/entropies/estimators/gao.jl
+++ b/test/entropies/estimators/gao.jl
@@ -3,11 +3,11 @@ using ComplexityMeasures, Test
 # Check if the estimator converge to true values for some distributions with
 # analytically derivable entropy.
 # -------------------------------------------------------------------------------------
-# EntropyDefinition to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
+# Entropy to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
 U = 0.00
-# EntropyDefinition with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
+# Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
 N = round(0.5*log(2π) + 0.5, digits = 2)
-N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
+N_base3 = ComplexityMeasures.convert_logunit(N, ℯ, 3)
 
 # Without correction
 # ------------------------------------------------------------------------------------
@@ -18,7 +18,7 @@ ea_n3 = entropy(Gao(k = 5, corrected = false, base = 3), randn(npts))
 
 # It is not expected that this estimator will be precise, so increase
 # allowed error bounds compared to other estimators.
-@test U - max(0.1, U*0.2) ≤ ea ≤ U + max(0.1, U*0.2)
+@test U - max(0.2, U*0.2) ≤ ea ≤ U + max(0.1, U*0.2)
 @test N * 0.8 ≤ ea_n ≤ N * 1.02
 @test N_base3 * 0.8 ≤ ea_n3 ≤ N_base3 * 1.02
 

--- a/test/entropies/estimators/goria.jl
+++ b/test/entropies/estimators/goria.jl
@@ -3,11 +3,11 @@ using ComplexityMeasures, Test
 # Check if the estimator converge to true values for some distributions with
 # analytically derivable entropy.
 # -------------------------------------------------------------------------------------
-# EntropyDefinition to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
+# Entropy to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
 U = 0.00
-# EntropyDefinition with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
+# Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
 N = round(0.5*log(2π) + 0.5, digits = 2)
-N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
+N_base3 = ComplexityMeasures.convert_logunit(N, ℯ, 3)
 
 npts = 1000000
 ea_n = entropy(Goria(k = 5, base = ℯ), randn(npts))

--- a/test/entropies/estimators/kozachenkoleonenko.jl
+++ b/test/entropies/estimators/kozachenkoleonenko.jl
@@ -2,11 +2,11 @@
 # Check if the estimator converge to true values for some distributions with
 # analytically derivable entropy.
 # -------------------------------------------------------------------------------------
-# EntropyDefinition to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
+# Entropy to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
 U = 0.00
-# EntropyDefinition with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
+# Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
 N = round(0.5*log(2π) + 0.5, digits = 2)
-N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
+N_base3 = ComplexityMeasures.convert_logunit(N, ℯ, 3)
 
 npts = 1000000
 ea = entropy(KozachenkoLeonenko(), rand(npts))

--- a/test/entropies/estimators/kraskov.jl
+++ b/test/entropies/estimators/kraskov.jl
@@ -3,11 +3,11 @@ using ComplexityMeasures, Test
 # Check if the estimator converge to true values for some distributions with
 # analytically derivable entropy.
 # -------------------------------------------------------------------------------------
-# EntropyDefinition to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
+# Entropy to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
 U = 0.00
-# EntropyDefinition with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
+# Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
 N = round(0.5*log(2π) + 0.5, digits = 2)
-N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
+N_base3 = ComplexityMeasures.convert_logunit(N, ℯ, 3)
 
 npts = 1000000
 ea = entropy(Kraskov(k = 5), rand(npts))

--- a/test/entropies/estimators/lord.jl
+++ b/test/entropies/estimators/lord.jl
@@ -3,11 +3,11 @@ using ComplexityMeasures, Test
 # Check if the estimator converge to true values for some distributions with
 # analytically derivable entropy.
 # -------------------------------------------------------------------------------------
-# Shannon entropy to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
+# Entropy to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
 U = 0.00
-# Shannon entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
+# Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
 N = round(0.5*log(2π) + 0.5, digits = 2)
-N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
+N_base3 = ComplexityMeasures.convert_logunit(N, ℯ, 3)
 
 npts = 20000 # a bit fewer points than for other tests, so tests don't take forever.
 ea = entropy(Lord(k = 20), rand(npts))

--- a/test/entropies/estimators/vasicek.jl
+++ b/test/entropies/estimators/vasicek.jl
@@ -3,11 +3,11 @@ using ComplexityMeasures, Test
 # Check if the estimator converge to true values for some distributions with
 # analytically derivable entropy.
 # -------------------------------------------------------------------------------------
-# EntropyDefinition to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
+# Entropy to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
 U = 0.00
-# EntropyDefinition with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
+# Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
 N = round(0.5*log(2π) + 0.5, digits = 2)
-N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
+N_base3 = ComplexityMeasures.convert_logunit(N, ℯ, 3)
 
 npts = 1000000
 ea = entropy(Vasicek(m = 100), rand(npts))

--- a/test/entropies/estimators/zhu.jl
+++ b/test/entropies/estimators/zhu.jl
@@ -11,11 +11,11 @@ y = StateSpaceSet([[3, 1], [-5, 1], [3, -2]]);
 # Check if the estimator converge to true values for some distributions with
 # analytically derivable entropy.
 # -------------------------------------------------------------------------------------
-# EntropyDefinition to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
+# Entropy to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
 U = 0.00
-# EntropyDefinition with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
+# Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
 N = round(0.5*log(2π) + 0.5, digits = 2)
-N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
+N_base3 = ComplexityMeasures.convert_logunit(N, ℯ, 3)
 
 npts = 1000000
 ea = entropy(Zhu(k = 5), rand(npts))

--- a/test/entropies/estimators/zhusingh.jl
+++ b/test/entropies/estimators/zhusingh.jl
@@ -32,11 +32,11 @@ vol = ComplexityMeasures.volume_minimal_rect(dists)
 # Check if the estimator converge to true values for some distributions with
 # analytically derivable entropy.
 # -------------------------------------------------------------------------------------
-# EntropyDefinition to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
+# Entropy to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
 U = 0.00
-# EntropyDefinition with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
+# Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
 N = round(0.5*log(2π) + 0.5, digits = 2)
-N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
+N_base3 = ComplexityMeasures.convert_logunit(N, ℯ, 3)
 
 npts = 1000000
 ea = entropy(ZhuSingh(k = 5), rand(npts))


### PR DESCRIPTION
- Fixes #256 

Summary:
- Introduces a convenience method `convert_logunit` that converts between numbers computed with different logarithm bases. This method is exported as a convenience function, and is tested, to ensure the errors in #256 can never occur. However, it is *not* documented yet. We can decide later if it should be.
- Consistently use `convert_logunit` for all differential entropy estimator code and tests.
- Updates changelog.
- Increments package version.