### PR TITLE
fix binning when max point in range

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ComplexityMeasures"
 uuid = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/ComplexityMeasures.jl.git"
-version = "2.7.1"
+version = "2.7.2"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/encoding_implementations/rectangular_binning.jl
+++ b/src/encoding_implementations/rectangular_binning.jl
@@ -163,10 +163,13 @@ function FixedRectangularBinning(b::RectangularBinning, x)
     if ϵ isa Float64 || ϵ isa AbstractVector{<:AbstractFloat}
         widths = SVector{D,T}(ϵ .* ones(SVector{D,T}))
         # To ensure all points are guaranteed to be covered, we add the width
-        # to the max, if the max isn't included in the resulting range
+        # to the max, if the max isn't included in the resulting range.
+        # We also add the width if the maximum is the end point of the range,
+        # as according to our definition, the end point of a range is NOT
+        # included in the histogram!
         ensure_covering_range = (i) -> begin
             r = range(mini[i], maxi[i]; step = widths[i])
-            if maxi[i] ∉ r
+            if (maxi[i] ∉ r) || (maxi[i] == r[end])
                 return range(mini[i], maxi[i] + widths[i]; step = widths[i])
             else
                 return r


### PR DESCRIPTION
While working on some fractal dimension estimators, I encountered this bug. If the maximum along a direction is exactly the end point of a range, our code does not extend the range for one more. This is wrong however as by our definition of the Fixed Binning,  the end point of the range is NOT included in the histogram, and hence the point itself is NOT included in the histogram, which is wrong.

This fixes it and adds a test.