### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,17 @@
 Changelog is kept with respect to version 0.11 of Entropies.jl. From version v2.0 onwards, this package has been renamed to ComplexityMeasures.jl.
 
 ## 2.8.0
+
 - New function `allprobabilities` that is like `probabilities` but also includes 0 entries for possible outcomes that were not present in the data.
+- `StatisticalComplexity` is now compatible with any normalizable `EntropyDefinition`.
+- Minor documentation fixes.
 
 ## 2.7.1
-- fix bug in calculation of statistical complexity
+
+- Fix bug in calculation of statistical complexity
 
 ## 2.7
+
 - Add generalized statistical complexity as complexity measure.
 
 ## 2.6


### PR DESCRIPTION
@Datseris FYI, I'm releasing v2.8 now, so we ensure that all analyses for the paper actually use the indicated version (2.8).
This will also allow immediate implementation of some bivariate measures in CausalityTools.jl, due to the new `allprobabilities` function.