### PR TITLE
Extropy

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,6 +6,7 @@ pages = [
     "probabilities.md",
     "encodings.md",
     "entropies.md",
+    "extropies.md",
     "complexity.md",
     "convenience.md",
     "examples.md",

--- a/docs/src/extropies.md
+++ b/docs/src/extropies.md
@@ -21,7 +21,7 @@ RenyiExtropy
 TsallisExtropy
 ```
 
-## Discrete xntropy
+## Discrete extropy
 
 ```@docs
 extropy(::ExtropyDefinition, ::ProbabilitiesEstimator, ::Any)

--- a/docs/src/extropies.md
+++ b/docs/src/extropies.md
@@ -1,0 +1,37 @@
+# [Extropies](@id extropies)
+
+## Extropies API
+
+The extropies API is defined by
+
+- [`ExtropyDefinition`](@ref)
+- [`extropy`](@ref)
+- [`DiscreteExtropyEstimator`](@ref)
+
+The extropy API is identical to the entropy API, except that the word "entropy" is
+replaced by "extropy" everywhere. We do not yet offer differential extropy estimators,
+although this will exist in the future (PRs are welcome!).
+
+## Extropy definitions
+
+```@docs
+ExtropyDefinition
+ShannonExtropy
+RenyiExtropy
+TsallisExtropy
+```
+
+## Discrete xntropy
+
+```@docs
+extropy(::ExtropyDefinition, ::ProbabilitiesEstimator, ::Any)
+extropy_maximum
+extropy_normalized
+```
+
+### Discrete extropy estimators
+
+```@docs
+DiscreteExtropyEstimator
+MLExtropy
+```

--- a/src/ComplexityMeasures.jl
+++ b/src/ComplexityMeasures.jl
@@ -17,6 +17,7 @@ const Vector_or_SSSet = Union{<:AbstractVector{<:Real}, <:AbstractStateSpaceSet}
 # Core API types and functions
 include("probabilities.jl")
 include("entropy.jl")
+include("extropy.jl")
 include("encodings.jl")
 include("complexity.jl")
 include("multiscale.jl")
@@ -26,6 +27,7 @@ include("convenience.jl")
 include("encoding_implementations/encoding_implementations.jl")
 include("probabilities_estimators/probabilities_estimators.jl")
 include("entropies_definitions/entropies_definitions.jl")
+include("extropies_definitions/extropies_definitions.jl")
 include("entropies_estimators/entropies_estimators.jl")
 include("complexity_measures/complexity_measures.jl")
 

--- a/src/complexity_measures/statistical_complexity.jl
+++ b/src/complexity_measures/statistical_complexity.jl
@@ -140,6 +140,10 @@ Calculate the maximum complexity-entropy curve for the statistical complexity ac
 for `num_max * total_outcomes(c.est)` different values of the normalized information measure of choice (in case of the maximum complexity curves)
 and `num_min` different values of the normalized information measure of choice (in case of the minimum complexity curve).
 
+This function can also be used to compute the maximum "complexity-extropy curve" if
+`c.entr` is an [`ExtropyDefinition`](@ref), which is the equivalent of the
+complexity-entropy curves, but using [`extropy`](@ref) instead of [`entropy`](@ref).
+
 ## Description
 
 The way the statistical complexity is designed, there is a minimum and maximum possible complexity

--- a/src/complexity_measures/statistical_complexity.jl
+++ b/src/complexity_measures/statistical_complexity.jl
@@ -9,7 +9,8 @@ export StatisticalComplexity, entropy_complexity, entropy_complexity_curves
 
 An estimator for the statistical complexity and entropy, originally by
 Rosso et al. (2007)[^Rosso2007], but here generalized (see [^Rosso2013]) to work with any probabilities
-estimator with a priori known `total_outcomes`, any valid distance metric, and any normalizable entropy definition.
+estimator with a priori known `total_outcomes`, any valid distance metric, and any normalizable entropy definition,
+or any normalizable extropy definition (not treated in Rosso et al.'s papers).
 Used with [`complexity`](@ref).
 
 ## Keyword arguments
@@ -20,7 +21,9 @@ Used with [`complexity`](@ref).
     estimating the distance between the estimated probability distribution and a uniform
     distribution with the same maximal number of outcomes.
 - `entr::EntropyDefinition = Renyi()`: An [`EntropyDefinition`](@ref) of choice. Any
-    entropy definition that defines `entropy_maximum` is valid here.
+    entropy definition that defines `entropy_maximum` is valid here. Alternatively,
+    an [`ExtropyDefinition`](@ref) can be used, in which case the [`extropy`](@ref) is
+    computed instead.
 
 ## Description
 
@@ -93,6 +96,13 @@ function entropy_complexity(c::StatisticalComplexity, x)
    return (c.entr_val[], compl)
 end
 
+# A small hack to allow both extropy and entropy to be used. This hasn't been done in
+# the literature before.
+entropy_or_extropy(e::ExtropyDefinition, x) = extropy(e, x)
+entropy_or_extropy(e::EntropyDefinition, x) = entropy(e, x)
+entropy_or_extropy_maximum(e::ExtropyDefinition, x) = extropy_maximum(e, x)
+entropy_or_extropy_maximum(e::EntropyDefinition, x) = entropy_maximum(e, x)
+
 function complexity(c::StatisticalComplexity, p::Probabilities)
     (; dist, est, entr) = c
 
@@ -105,7 +115,7 @@ function complexity(c::StatisticalComplexity, p::Probabilities)
             you must set `p = allprobabilities(est, x)`."
             ))
     end
-    H_q = entropy(entr, p) / entropy_maximum(entr, est)
+    H_q = entropy_or_extropy(entr, p) / entropy_or_extropy_maximum(entr, est)
 
     # calculate distance between calculated distribution and uniform one
     D_q = evaluate(dist, vec(p), fill(1.0/L, L))

--- a/src/extropies_definitions/extropies_definitions.jl
+++ b/src/extropies_definitions/extropies_definitions.jl
@@ -1,0 +1,3 @@
+include("shannon.jl")
+include("tsallis.jl")
+include("renyi.jl")

--- a/src/extropies_definitions/extropy_definitions.jl
+++ b/src/extropies_definitions/extropy_definitions.jl
@@ -1,8 +1,0 @@
-export ExtropyDefinition
-
-"""
-    ExtropyDefinition
-
-The supertype of all extropy definitions.
-"""
-abstract type ExtropyDefinition end

--- a/src/extropies_definitions/extropy_definitions.jl
+++ b/src/extropies_definitions/extropy_definitions.jl
@@ -1,0 +1,8 @@
+export ExtropyDefinition
+
+"""
+    ExtropyDefinition
+
+The supertype of all extropy definitions.
+"""
+abstract type ExtropyDefinition end

--- a/src/extropies_definitions/renyi.jl
+++ b/src/extropies_definitions/renyi.jl
@@ -1,0 +1,63 @@
+export RenyiExtropy
+
+"""
+    RenyiExtropy <: ExtropyDefinition
+    RenyiExtropy(; q = 1.0, base = 2)
+
+The Rényi extropy (Liu & Xiao, 2021[^Liu2021]).
+
+## Description
+
+`RenyiExtropy` is used [`extropy`](@ref) to compute
+
+```math
+J_R(P) = \\dfrac{-(n - 1)
+\\log(n-1) + (n-1)\\log \\( \\sum_{i=1}^N ( 1 - p[i])^q \\)}{q - 1}}
+```
+
+for a probability distribution ``P = \\{p_1, p_2, \\ldots, p_N\\}``,
+with the ``\\log`` at the given `base`. Alternatively, `RenyiExtropy` can be used
+with [`extropy_normalized`](@ref), which ensures that the computed extropy is
+on the interval ``[0, 1]`` by normalizing to to the maximal Rényi extropy, given by
+
+```math
+J_R(P) = (N - 1)\\log\\( \\dfrac{n}{n-1} \\).
+```
+
+[^Liu2021]:
+    Liu, J., & Xiao, F. (2021). Renyi extropy. Communications in Statistics-Theory and
+    Methods, 1-12.
+"""
+struct RenyiExtropy{Q,B} <: ExtropyDefinition
+    q::Q
+    base::B
+end
+RenyiExtropy(q; base = 2) = RenyiExtropy(q, base)
+RenyiExtropy(; q = 1.0, base = 2) = RenyiExtropy(q, base)
+
+function extropy(e::RenyiExtropy, probs::Probabilities)
+    (; q, base) = e
+
+    if length(probs) == 1
+        return 0.0
+    end
+
+    if q ≈ 1
+        return extropy(ShannonExtropy(; base), probs)
+    else
+        N = length(probs)
+        num = -(N - 1)*log(base, N - 1) + (N - 1)*log(base, sum((1 - pᵢ)^q for pᵢ in probs))
+        den = 1 - q
+        return num / den
+    end
+end
+
+function extropy_maximum(e::RenyiExtropy, L::Int)
+    (; q, base) = e
+
+    if L == 1
+        return 0.0
+    end
+
+    return (L - 1) * log(base, L / (L - 1))
+end

--- a/src/extropies_definitions/renyi.jl
+++ b/src/extropies_definitions/renyi.jl
@@ -11,8 +11,7 @@ The Rényi extropy (Liu & Xiao, 2021[^Liu2021]).
 `RenyiExtropy` is used [`extropy`](@ref) to compute
 
 ```math
-J_R(P) = \\dfrac{-(n - 1)
-\\log(n-1) + (n-1)\\log \\( \\sum_{i=1}^N ( 1 - p[i])^q \\)}{q - 1}}
+J_R(P) = \\dfrac{-(n - 1)\\log(n-1) + (n-1) \\log\\( \\sum_{i=1}^N (1 - p[i])^q \\)}{q - 1}
 ```
 
 for a probability distribution ``P = \\{p_1, p_2, \\ldots, p_N\\}``,
@@ -21,7 +20,7 @@ with [`extropy_normalized`](@ref), which ensures that the computed extropy is
 on the interval ``[0, 1]`` by normalizing to to the maximal Rényi extropy, given by
 
 ```math
-J_R(P) = (N - 1)\\log\\( \\dfrac{n}{n-1} \\).
+J_R(P) = (N - 1)\\log \\( \\dfrac{n}{n-1} \\).
 ```
 
 [^Liu2021]:

--- a/src/extropies_definitions/shannon.jl
+++ b/src/extropies_definitions/shannon.jl
@@ -10,6 +10,7 @@ The Shannon extropy (Lad et al., 2015[^Lad2015]), used with [`extropy`](@ref) to
 J(x) -\\sum_{i=1}^N (1 - p[i]) \\log{(1 - p[i])},
 ```
 
+for a probability distribution ``P = \\{p_1, p_2, \\ldots, p_N\\}``,
 with the ``\\log`` at the given `base`.
 
 [^Lad2015]:
@@ -19,10 +20,18 @@ Base.@kwdef struct ShannonExtropy{B} <: ExtropyDefinition
     base::B = 2
 end
 
-function extropy(e::ShannonExtropy, p::Probabilities)
-    -sum((1 - pᵢ) * log(e.base, 1 - pᵢ) for pᵢ in p)
+function extropy(e::ShannonExtropy, probs::Probabilities)
+    if length(probs) == 1
+        return 0.0
+    end
+
+    return -sum((1 - pᵢ) * log(e.base, 1 - pᵢ) for pᵢ in probs)
 end
 
 function extropy_maximum(e::ShannonExtropy, L::Int)
+    if L == 1
+        return 0.0
+    end
+
     return (L - 1) * log(e.base, L / (L - 1))
 end

--- a/src/extropies_definitions/shannon.jl
+++ b/src/extropies_definitions/shannon.jl
@@ -1,0 +1,28 @@
+export ShannonExtropy
+
+"""
+    ShannonExtropy <: ExtropyDefinition
+    ShannonExtropy(; base = 2)
+
+The Shannon extropy (Lad et al., 2015[^Lad2015]), used with [`extropy`](@ref) to compute
+
+```math
+J(x) -\\sum_{i=1}^N (1 - p[i]) \\log{(1 - p[i])},
+```
+
+with the ``\\log`` at the given `base`.
+
+[^Lad2015]:
+    Lad, F., Sanfilippo, G., & Agro, G. (2015). Extropy: Complementary dual of entropy.
+"""
+Base.@kwdef struct ShannonExtropy{B} <: ExtropyDefinition
+    base::B = 2
+end
+
+function extropy(e::ShannonExtropy, p::Probabilities)
+    -sum((1 - pᵢ) * log(e.base, 1 - pᵢ) for pᵢ in p)
+end
+
+function extropy_maximum(e::ShannonExtropy, L::Int)
+    return (L - 1) * log(e.base, L / (L - 1))
+end

--- a/src/extropies_definitions/tsallis.jl
+++ b/src/extropies_definitions/tsallis.jl
@@ -11,7 +11,7 @@ The Tsallis extropy (Xue & Deng[^Xue2023]).
 `TsallisExtropy` is used with [`extropy`](@ref) to compute
 
 ```math
-J_T(P) = k \\dfrac{n - 1 - \\sum_{i=1}^N ( 1 - p[i])^q}{q - 1}
+J_T(P) = k \\dfrac{N - 1 - \\sum_{i=1}^N ( 1 - p[i])^q}{q - 1}
 ```
 
 for a probability distribution ``P = \\{p_1, p_2, \\ldots, p_N\\}``,

--- a/src/extropies_definitions/tsallis.jl
+++ b/src/extropies_definitions/tsallis.jl
@@ -1,0 +1,62 @@
+export TsallisExtropy
+
+"""
+    TsallisExtropy <: ExtropyDefinition
+    TsallisExtropy(; base = 2)
+
+The Tsallis extropy (Xue & Deng[^Xue2023]).
+
+## Description
+
+`TsallisExtropy` is used with [`extropy`](@ref) to compute
+
+```math
+J_T(P) = k \\dfrac{n - 1 - \\sum_{i=1}^N ( 1 - p[i])^q}{q - 1}
+```
+
+for a probability distribution ``P = \\{p_1, p_2, \\ldots, p_N\\}``,
+with the ``\\log`` at the given `base`. Alternatively, `TsallisExtropy` can be used
+with [`extropy_normalized`](@ref), which ensures that the computed extropy is
+on the interval ``[0, 1]`` by normalizing to to the maximal Tsallis extropy, given by
+
+```math
+J_T(P) = \\dfrac{(N - 1)N^{q - 1} - (N - 1)^q}{(q - 1)N^{q - 1}}
+```
+
+[^Xue2023]:
+    Xue, Y., & Deng, Y. (2023). Tsallis extropy. Communications in Statistics-Theory and
+    Methods, 52(3), 751-762.
+"""
+struct TsallisExtropy{Q,K,B} <: ExtropyDefinition
+    q::Q
+    k::K
+    base::B
+end
+TsallisExtropy(q; k = 1.0, base = 2) = TsallisExtropy(q, k, base)
+TsallisExtropy(; q = 1.0, k = 1.0, base = 2) = TsallisExtropy(q, k, base)
+
+function extropy(e::TsallisExtropy, probs::Probabilities)
+    (; q, k, base) = e
+
+    if length(probs) == 1
+        return 0.0
+    end
+
+    if q ≈ 1
+        return extropy(ShannonExtropy(; base), probs)
+    else
+        N = length(probs)
+        c = k / (q - 1)
+        return c * (N - 1 - sum((1 - pᵢ)^q for pᵢ in probs))
+    end
+end
+
+function extropy_maximum(e::TsallisExtropy, L::Int)
+    (; q, k, base) = e
+
+    if L == 1
+        return 0.0
+    end
+
+    return ((L - 1) * L^(q - 1) - (L - 1)^q) / ((q - 1) * L^(q - 1))
+end

--- a/src/extropy.jl
+++ b/src/extropy.jl
@@ -1,0 +1,99 @@
+export extropy
+export extropy_maximum
+export extropy_normalized
+
+"""
+    DiscreteExtropyEstimator
+    DiscExtropyEst # alias
+
+Supertype of all discrete extropy estimators.
+
+Currently only the [`MLExtropy`](@ref) estimator is provided,
+which does not need to be used, as using an [`ExtropyDefinition`](@ref) directly in
+[`extropy`](@ref) is possible. In the future, more advanced estimators will
+be added.
+"""
+abstract type DiscreteExtropyEstimator end
+const DiscExtropyEst = DiscreteExtropyEstimator
+
+# Dummy estimator that doesn't actually change anything from the definitions
+"""
+    MLExtropy(e::ExtropyDefinition) <: DiscreteExtropyEstimator
+
+Standing for "maximum likelihood extropy", and also called empirical/naive/plug-in,
+this estimator calculates the extropy exactly as defined in the given
+[`ExtropyDefinition`](@ref) directly from a probability mass function.
+"""
+struct MLExtropy{E<:ExtropyDefinition} <: DiscreteExtropyEstimator
+    definition::E
+end
+
+"""
+    extropy(e::ExtropyDefinition, est::ProbabilitiesEstimator, x)
+
+Compute the extropy of type `e` from the probabilities estimated from `x`
+using the given [`ProbabilitiesEstimator`](@ref).
+
+See also: [`ExtropyDefinition`](@ref).
+"""
+function extropy end
+
+function extropy(e::ExtropyDefinition, est::ProbabilitiesEstimator, x)
+    ps = probabilities(est, x)
+    return extropy(e, ps)
+end
+
+# dispatch for `extropy(e::EntropyDefinition, ps::Probabilities)`
+# is in the individual extropy definitions files
+
+# Convenience
+extropy(est::ProbabilitiesEstimator, x) = entropy(ShannonExtropy(), est, x)
+extropy(probs::Probabilities) = extropy(ShannonExtropy(), probs)
+extropy(e::MLExtropy, args...) = extropy(e.definition, args...)
+
+"""
+    extropy_maximum(e::ExtropyDefinition, est::ProbabilitiesEstimator, x)
+
+Compute the extropy of type `e` from the probabilities estimated from `x`
+using the given [`ProbabilitiesEstimator`](@ref).
+
+See also: [`ExtropyDefinition`](@ref).
+"""
+function extropy_maximum end
+
+function extropy_maximum(e::ExtropyDefinition, est::ProbabilitiesEstimator, x)
+    L = total_outcomes(est, x)
+    return entropy_maximum(e, L)
+end
+
+function extropy_maximum(e::ExtropyDefinition, est::ProbabilitiesEstimator)
+    L = total_outcomes(est)
+    return entropy_maximum(e, L)
+end
+
+function extropy_maximum(e::ExtropyDefinition, ::Int)
+    error("not implemented for extropy type $(nameof(typeof(e))).")
+end
+extropy_maximum(e::MLExtropy, args...) = entropy_maximum(e.definition, args...)
+
+"""
+    extropy_normalized([e::DiscreteExtropyEstimator,] est::ProbabilitiesEstimator, x) → h̃
+
+Return `j̃ ∈ [0, 1]`, the normalized discrete extropy of `x`, i.e. the value of [`extropy`](@ref)
+divided by the maximum value for `e`, according to the given probabilities estimator.
+
+Instead of a discrete extropy estimator, an [`ExtropyDefinition`](@ref)
+can be given as first argument. If `e` is not given, it defaults to `ShannonExtropy()`.
+
+Notice that there is no method
+`extropy_normalized(e::DiscreteExtropyEstimator, probs::Probabilities)`,
+because there is no way to know
+the amount of _possible_ events (i.e., the [`total_outcomes`](@ref)) from `probs`.
+"""
+function extropy_normalized(e::ExtropyDefinition, est::ProbabilitiesEstimator, x)
+    return extropy(e, est, x) / extropy_maximum(e, est, x)
+end
+function extropy_normalized(est::ProbabilitiesEstimator, x::Array_or_SSSet)
+    return extropy_normalized(ShannonExtropy(), est, x)
+end
+extropy_normalized(e::MLExtropy, est, x) = extropy_normalized(e.definition, est, x)

--- a/src/extropy.jl
+++ b/src/extropy.jl
@@ -2,6 +2,8 @@ export extropy
 export extropy_maximum
 export extropy_normalized
 export ExtropyDefinition
+export DiscreteExtropyEstimator
+export MLExtropy
 
 """
     ExtropyDefinition
@@ -12,8 +14,9 @@ see description below.
 
 Currently implemented extropy definitions are:
 
+- [`RenyiExtropy`](@ref).
 - [`TsallisExtropy`](@ref).
-- [`ShannonExtropy`](@ref), which is a subcase of the above in the limit `q → 1`.
+- [`ShannonExtropy`](@ref), which is a subcase of the two above in the limit `q → 1`.
 
 These types can be given as inputs to [`extropy`](@ref) or [`extropy_normalized`](@ref).
 """
@@ -45,16 +48,31 @@ struct MLExtropy{E<:ExtropyDefinition} <: DiscreteExtropyEstimator
     definition::E
 end
 
-"""
-    extropy(e::ExtropyDefinition, est::ProbabilitiesEstimator, x)
-
-Compute the extropy of type `e` from the probabilities estimated from `x`
-using the given [`ProbabilitiesEstimator`](@ref).
-
-See also: [`ExtropyDefinition`](@ref).
-"""
 function extropy end
 
+"""
+    extropy([e::DiscreteExtropyEstimator,] probs::Probabilities)
+    extropy([e::DiscreteExtropyEstimator,] est::ProbabilitiesEstimator, x)
+
+Compute the **discrete extropy** `h::Real ∈ [0, ∞)`,
+using the estimator `est`, in one of two ways:
+
+1. Directly from existing [`Probabilities`](@ref) `probs`.
+2. From input data `x`, by first estimating a probability mass function using the provided
+   [`ProbabilitiesEstimator`](@ref), and then computing the extropy from that mass fuction
+   using the provided [`DiscreteExtropyEstimator`](@ref).
+
+Instead of providing a [`DiscreteExtropyEstimator`](@ref), an [`ExtropyDefinition`](@ref)
+can be given directly, in which case [`MLExtropy`](@ref) is used as the estimator.
+If `e` is not provided, [`ShannonExtropy`](@ref)`()` is used by default.
+
+## Maximum extropy and normalized extropy
+
+All discrete extropies have a well defined maximum value for a given probability estimator.
+To obtain this value one only needs to call the [`extropy_maximum`](@ref).
+Or, one can use [`extropy_normalized`](@ref)
+to obtain the normalized form of the extropy (divided by the maximum).
+"""
 function extropy(e::ExtropyDefinition, est::ProbabilitiesEstimator, x)
     ps = probabilities(est, x)
     return extropy(e, ps)

--- a/test/complexity/measures/statistical_complexity.jl
+++ b/test/complexity/measures/statistical_complexity.jl
@@ -87,3 +87,21 @@ rng = MersenneTwister(1234)
     )
     @test_throws ErrorException complexity(c, x)
 end
+
+
+@testset "StatisticalComplexity with extropy" begin
+    x = randn(rng, 10000)
+
+    # As with regular entropy, for extropy, the edge case of noise should be close to zeros
+    c = StatisticalComplexity(
+        dist=JSDivergence(),
+        est=SymbolicPermutation(; m, τ),
+        entr=TsallisExtropy(q = 5)
+    )
+
+    # complexity of white noise should be very close to zero
+    compl = complexity(c, x)
+    @test 0 < compl < 0.02
+    compl = complexity(c, collect(1:100))
+    @test compl == 0.0
+end

--- a/test/complexity/measures/statistical_complexity.jl
+++ b/test/complexity/measures/statistical_complexity.jl
@@ -1,10 +1,12 @@
 using ComplexityMeasures, Distances, DynamicalSystemsBase
 using Test
+using Random
+rng = MersenneTwister(1234)
 
 @testset "Statistical Complexity" begin
 
     m, τ = 6, 1
-    x = randn(10000)
+    x = randn(rng, 10000)
     c = StatisticalComplexity(
         dist=JSDivergence(),
         est=SymbolicPermutation(; m, τ),

--- a/test/extropies/extropies.jl
+++ b/test/extropies/extropies.jl
@@ -1,0 +1,3 @@
+include("shannon.jl")
+include("tsallis.jl")
+include("renyi.jl")

--- a/test/extropies/renyi.jl
+++ b/test/extropies/renyi.jl
@@ -1,0 +1,39 @@
+
+# Minimized for one-element distributions, where there is total order.
+x = [0.1, 0.1, 0.1]
+@test extropy(RenyiExtropy(q = 2), CountOccurrences(), x) == 0.0
+@test extropy_normalized(RenyiExtropy(q = 2), CountOccurrences(), x) == 0.0
+
+
+# Example 3.2 from Liu & Xiao (2021) (equivalence of Rényi entropy/extropy for
+# two-element distributions)
+x = [0.2, 0.4, 0.4]
+h = entropy(Renyi(; q = 2, base = MathConstants.e), CountOccurrences(), x)
+j = extropy(RenyiExtropy(; q = 2, base = MathConstants.e), CountOccurrences(), x)
+@test round(h, digits = 4) ≈ round(j, digits = 4) ≈ 0.5878
+
+# Example 3.1 from Liu & Xiao (2021) (equivalence of Rényi entropy/extropy for
+# two-element distributions). They use natural logs - otherwise the numbers don't
+# make any sense.
+x = [0.2, 0.2, 0.4, 0.4, 0.6, 0.6]
+h = entropy(Renyi(; q = 2, base = MathConstants.e), CountOccurrences(), x)
+j = extropy(RenyiExtropy(; q = 2, base = MathConstants.e), CountOccurrences(), x)
+@test round(h, digits = 4) ≈ 1.0986
+@test round(j, digits = 4) ≈ 0.8109
+
+# In general, normalized Rényi extropy should be maximized (i.e. be equal to 1) for a
+# uniform distribution.
+x = [0.2, 0.2, 0.4, 0.4, 0.5, 0.5, 0.6, 0.6]
+jr = extropy_normalized(RenyiExtropy(; q = 2), CountOccurrences(), x)
+@test jr ≈ 1
+
+# The maximum Rényi extropy should be insensitive to the base of the logarithm.
+x = [0.2, 0.2, 0.4, 0.4, 0.5, 0.5, 0.6, 0.6]
+j2 = RenyiExtropy(; q = 2, base = 2)
+j10 = RenyiExtropy(; q = 2, base = 10)
+est = CountOccurrences()
+@test extropy_normalized(j2, est, x) ≈ extropy_normalized(j10, est, x)
+
+# The Rényi extropy should equal the Shannon extropy for q = 1
+jq1 = RenyiExtropy(; q = 2, base = 2)
+@test extropy(jq1, est, x) ≈ extropy(ShannonExtropy(; base = 2), est, x)

--- a/test/extropies/shannon.jl
+++ b/test/extropies/shannon.jl
@@ -1,0 +1,22 @@
+
+
+# Minimized for one-element distributions, where there is total order.
+x = [0.1, 0.1, 0.1]
+@test extropy(ShannonExtropy(), CountOccurrences(), x) == 0.0
+@test extropy_normalized(ShannonExtropy(), CountOccurrences(), x) == 0.0
+
+# Normalized Shannon extropy should be maximized (i.e. be equal to 1) for a
+# uniform distribution.
+x = [0.2, 0.2, 0.4, 0.4, 0.5, 0.5, 0.6, 0.6]
+js = extropy_normalized(ShannonExtropy(), CountOccurrences(), x)
+@test js ≈ 1
+
+# It should be less than 1 for non-uniform distributions
+x = [0.2, 0.3, 0.4, 0.4, 0.5, 0.5, 0.6, 0.6]
+js = extropy_normalized(ShannonExtropy(), CountOccurrences(), x)
+@test js < 1
+
+# Correctness of maximum
+x = [0.2, 0.2, 0.4, 0.4, 0.5, 0.5]
+js = extropy(ShannonExtropy(base = 2), CountOccurrences(), x)
+@test js ≈ (3 - 1)*log(2, (3 / (3 - 1)))

--- a/test/extropies/tsallis.jl
+++ b/test/extropies/tsallis.jl
@@ -1,0 +1,30 @@
+# Minimized for one-element distributions, where there is total order.
+x = [0.1, 0.1, 0.1]
+@test extropy(TsallisExtropy(q = 2), CountOccurrences(), x) == 0.0
+@test extropy_normalized(TsallisExtropy(q = 2), CountOccurrences(), x) == 0.0
+
+
+# Example 3.5 from Xue & Deng (2023) (equivalence of Tsallis entropy/extropy for
+# two-element distributions)
+x = [0.2, 0.4, 0.4]
+h = entropy(Tsallis(; q = 2), CountOccurrences(), x)
+j = extropy(TsallisExtropy(; q = 2), CountOccurrences(), x)
+@test 2h ≈ 2j ≈ 8/9
+
+# Example 3.4 from Xue & Deng (2023) (equivalence of Tsallis entropy/extropy for
+# two-element distributions)
+x = [0.2, 0.4]
+h = entropy(Tsallis(; q = 2), CountOccurrences(), x)
+j = extropy(TsallisExtropy(; q = 2), CountOccurrences(), x)
+@test 2h ≈ 2j ≈ 1.0
+
+# Example 3.9 from Xue & Deng (2023)
+x = [0.2, 0.2, 0.4, 0.4, 0.5, 0.5]
+j = extropy(TsallisExtropy(; q = 2), CountOccurrences(), x)
+@test j ≈ 2/3
+
+# In general, normalized Tsallis extropy should be maximized (i.e. be equal to 1) for a
+# uniform distribution.
+x = [0.2, 0.2, 0.4, 0.4, 0.5, 0.5, 0.6, 0.6]
+jn = extropy_normalized(TsallisExtropy(; q = 2), CountOccurrences(), x)
+@test jn == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ testfile(file, testname=defaultname(file)) = @testset "$testname" begin; include
 
 
     include("entropies/entropies.jl")
+    include("extropies/extropies.jl")
     include("complexity/complexity.jl")
 
     # When multiscale is exported, this should be turned on


### PR DESCRIPTION
WIP (but from my side: quite ready). I'd very much like your input on this, @Datseris. 

This PR replaces up a few of the old extropy-related branches that we need to remove as part of https://github.com/orgs/JuliaDynamics/projects/5?pane=issue&itemId=32875018 (but there's still a few things that need to get transferred before merging).

This PR does the following:

- Introduces the extropy measure. It is the complementary dual measure of entropy, and thus the API for both measures is identical, but with different names.
- We've had multiple discussions about extropy in the past, and how to implement it, thinking about its relation to entropy. After our final API design, I think the approach here is the most natural: just blatantly copy the entropy API, but introduce unique extropy definitions. That means that `ShannonExtropy` and `TsallisExtropy` are the analogues to `Shannon` and `Tsallis` entropy definitions. `entropy`/`entropy_maximum`/`entropy_normalized` have `extropy`/`extropy_maximum`/`extropy_normalized`. Then dispatch takes care of the rest. We talked about letting extropy definitions work with `entropy` before, but I think the approach here is the most reasonable way to go, since they are *distinct* measures. They both are functionals of probabilities, but are *distinct* functionals.
- `StatisticalComplexity` now works with both entropies and extropies, both for 1-D and N-D data (this is entirely new, and we can write a paper exploring its usage).

Questions:
- I'd like a convencience function `entropy_or_extropy(e, args...)`, which just dispatches to relevant methods below. That way, I can use a single function to loop over entropy AND extropy definitions whenever I want to use either to quantify e.g. complexity in some way. Yay or nay?