### PR TITLE
Generic dispatch for `probabilities`

### DIFF
--- a/docs/src/devdocs.md
+++ b/docs/src/devdocs.md
@@ -20,13 +20,16 @@ All PRs contributing new functionality must be well tested and well documented. 
 
 If your new outcome space is counting-based, then
 
-5. Implement dispatch for [`counts_and_outcomes`](@ref) for your [`OutcomeSpace`](@ref) type.
+5. Implement dispatch for [`counts_and_outcomes`](@ref) for your [`OutcomeSpace`](@ref)
+    type. You'll then get [`counts`](@ref) for free. Optionally, you can
+    implement [`counts`](@ref) too if it leads to performance gains.
 
 If your new outcome space is not counting-based, then
 
 6. Implement dispatch for [`probabilities_and_outcomes`](@ref) for your
     [`OutcomeSpace`](@ref) type. You'll then get the methods for
-    [`probabilities`](@ref) and [`outcomes`](@ref) for free.
+    [`probabilities`](@ref) and [`outcomes`](@ref) for free. Optionally, you can
+    implement [`probabilities`](@ref) too if it leads to performance gains.
 
 Finally,
 

--- a/docs/src/devdocs.md
+++ b/docs/src/devdocs.md
@@ -4,25 +4,68 @@ Good practices in developing a code base apply in every Pull Request. The [Good 
 
 All PRs contributing new functionality must be well tested and well documented. You only need to add tests for methods that you **explicitly** extended.
 
-## Adding a new `ProbabilitiesEstimator`
+## Adding a new `OutcomeSpace`
 
 ### Mandatory steps
 
 1. Decide on the outcome space and how the estimator will map probabilities to outcomes.
-2. Define your type and make it subtype [`ProbabilitiesEstimator`](@ref).
+2. Define your type and make it subtype [`OutcomeSpace`](@ref).
 3. Add a docstring to your type following the style of the docstrings of other estimators.
-4. If suitable, the estimator may be able to operate based on [`Encoding`](@ref)s. If so, it is preferred to implement an `Encoding` subtype and extend the methods [`encode`](@ref) and [`decode`](@ref). This will allow your probabilities estimator to be used with a larger span of entropy and complexity methods without additional effort. Have a look at the file defining [`OrdinalPatterns`](@ref) for an idea of how this works.
-5. Implement dispatch for [`probabilities_and_outcomes`](@ref) and your probabilities estimator type.
-6. Implement dispatch for [`outcome_space`](@ref) and your probabilities estimator type. The return value of `outcome_space` must be sorted (as in the default behavior of `sort`, in ascending order).
-7. Add your probabilities estimator type to the table list in the documentation page of probabilities. If you made an encoding, also add it to corresponding table in the encodings section.
+4. If suitable, the estimator may be able to operate based on [`Encoding`](@ref)s. If so,
+    it is preferred to implement an `Encoding` subtype and extend the methods
+    [`encode`](@ref) and [`decode`](@ref). This will allow your outcome space to be used
+    with a larger span of entropy and complexity methods without additional effort.
+    Have a look at the file defining [`OrdinalPatterns`](@ref) for an idea of how this
+    works.
+
+If your new outcome space is counting-based, then
+
+5. Implement dispatch for [`counts`](@ref) for your [`OutcomeSpace`](@ref) type.
+6. Implement dispatch for [`counts_and_outcomes`](@ref) for your [`OutcomeSpace`](@ref) type.
+
+If your new outcome space is not counting-based, then
+
+7. Implement dispatch for [`probabilities`](@ref) for your [`OutcomeSpace`](@ref) type.
+8. Implement dispatch for [`probabilities_and_outcomes`](@ref) for your
+    [`OutcomeSpace`](@ref) type.
+
+Finally,
+
+9. Implement dispatch for [`outcome_space`](@ref) and your [`OutcomeSpace`](@ref) type.
+    The return value of `outcome_space` must be sorted (as in the default behavior of
+    `sort`, in ascending order).
+10. Add your outcome space type to the table list in the documentation page of outcome
+    space. If you made an encoding, also add it to corresponding table in the encodings
+    section.
 
 ### Optional steps
 
-You may extend any of the following functions if there are potential performance benefits in doing so:
+1. [`outcomes`](@ref). By default calls [`probabilities_and_outcomes`](@ref) and returns
+    the second value.
+2. [`total_outcomes`](@ref). By default it returns the `length` of [`outcome_space`](@ref).
+    This is the function that most typically has performance benefits if implemented
+    explicitly, so most existing estimators extend it by default.
 
-1. [`probabilities`](@ref). By default it calls `probabilities_and_outcomes` and returns the first value.
-2. [`outcomes`](@ref). By default calls `probabilities_and_outcomes` and returns the second value.
-3. [`total_outcomes`](@ref). By default it returns the `length` of [`outcome_space`](@ref). This is the function that most typically has performance benefits if implemented explicitly, so most existing estimators extend it by default.
+## Adding a new [`ProbabilitiesEstimator`](@ref)
+
+### Mandatory steps 
+
+1. Define your type and make it subtype [`ProbabilitiesEstimator`](@ref).
+2. Add a docstring to your type following the style of the docstrings of other
+    [`ProbabilitiesEstimator`](@ref)s.
+3. Implement dispatch for [`probabilities_and_outcomes`](@ref) for your
+    [`ProbabilitiesEstimator`](@ref) type.
+4. Implement dispatch for [`allprobabilities_and_outcomes`](@ref) for your
+    [`ProbabilitiesEstimator`](@ref) type.
+5. Add your new [`ProbabilitiesEstimator`](@ref) type to the list of probabilities
+    estimators in the probabilities estimators documentation section.
+
+### Optional steps
+
+1. Implement dispatch for [`probabilities`](@ref) for your [`ProbabilitiesEstimator`](@ref)
+    if doing so leads to more efficient code.
+2. Implement dispatch for [`allprobabilities`](@ref) for your [`ProbabilitiesEstimator`](@ref)
+    if doing so leads to more efficient code.
 
 ## Adding a new `InformationMeasureEstimator`
 
@@ -33,6 +76,7 @@ InformationMeasureEstimator
 ```
 
 ## Adding a new `InformationMeasure`
+
 This amounts to adding a new definition of an information measure, not an estimator. It de-facto means adding a method for the discrete Plug-In estimator.
 
 ### Mandatory steps

--- a/docs/src/devdocs.md
+++ b/docs/src/devdocs.md
@@ -20,35 +20,40 @@ All PRs contributing new functionality must be well tested and well documented. 
 
 If your new outcome space is counting-based, then
 
-5. Implement dispatch for [`counts`](@ref) for your [`OutcomeSpace`](@ref) type.
-6. Implement dispatch for [`counts_and_outcomes`](@ref) for your [`OutcomeSpace`](@ref) type.
+5. Implement dispatch for [`counts_and_outcomes`](@ref) for your [`OutcomeSpace`](@ref) type.
 
 If your new outcome space is not counting-based, then
 
-7. Implement dispatch for [`probabilities`](@ref) for your [`OutcomeSpace`](@ref) type.
-8. Implement dispatch for [`probabilities_and_outcomes`](@ref) for your
+6. Implement dispatch for [`probabilities`](@ref) for your [`OutcomeSpace`](@ref) type.
+7. Implement dispatch for [`probabilities_and_outcomes`](@ref) for your
     [`OutcomeSpace`](@ref) type.
 
 Finally,
 
-9. Implement dispatch for [`outcome_space`](@ref) and your [`OutcomeSpace`](@ref) type.
+8. Implement dispatch for [`outcome_space`](@ref) and your [`OutcomeSpace`](@ref) type.
     The return value of `outcome_space` must be sorted (as in the default behavior of
     `sort`, in ascending order).
-10. Add your outcome space type to the table list in the documentation page of outcome
+9. Add your outcome space type to the table list in the documentation page of outcome
     space. If you made an encoding, also add it to corresponding table in the encodings
     section.
 
 ### Optional steps
 
-1. [`outcomes`](@ref). By default calls [`probabilities_and_outcomes`](@ref) and returns
+The following methods may be extended for your [`OutcomeSpace`](@ref) if doing so
+leads to performance benefits.
+
+1. [`counts`](@ref). Implementing this method for your [`OutcomeSpace`](@ref) type
+    is typically more performant than dispatching to `first(counts_and_outcomes(...))`.
+    In fact, most existing count-based outcome spaces implements [`counts`](@ref) explicitly.
+2. [`outcomes`](@ref). By default calls [`probabilities_and_outcomes`](@ref) and returns
     the second value.
-2. [`total_outcomes`](@ref). By default it returns the `length` of [`outcome_space`](@ref).
+3. [`total_outcomes`](@ref). By default it returns the `length` of [`outcome_space`](@ref).
     This is the function that most typically has performance benefits if implemented
     explicitly, so most existing estimators extend it by default.
 
 ## Adding a new [`ProbabilitiesEstimator`](@ref)
 
-### Mandatory steps 
+### Mandatory steps
 
 1. Define your type and make it subtype [`ProbabilitiesEstimator`](@ref).
 2. Add a docstring to your type following the style of the docstrings of other
@@ -62,10 +67,11 @@ Finally,
 
 ### Optional steps
 
-1. Implement dispatch for [`probabilities`](@ref) for your [`ProbabilitiesEstimator`](@ref)
-    if doing so leads to more efficient code.
-2. Implement dispatch for [`allprobabilities`](@ref) for your [`ProbabilitiesEstimator`](@ref)
-    if doing so leads to more efficient code.
+The following methods may be extended for your [`ProbabilitiesEstimator`](@ref) if doing so
+leads to performance benefits.
+
+1. [`probabilities`](@ref).
+2. [`allprobabilities`](@ref).
 
 ## Adding a new `InformationMeasureEstimator`
 

--- a/docs/src/devdocs.md
+++ b/docs/src/devdocs.md
@@ -24,9 +24,9 @@ If your new outcome space is counting-based, then
 
 If your new outcome space is not counting-based, then
 
-6. Implement dispatch for [`probabilities`](@ref) for your [`OutcomeSpace`](@ref) type.
-7. Implement dispatch for [`probabilities_and_outcomes`](@ref) for your
-    [`OutcomeSpace`](@ref) type.
+6. Implement dispatch for [`probabilities_and_outcomes`](@ref) for your
+    [`OutcomeSpace`](@ref) type. You'll then get the methods for
+    [`probabilities`](@ref) and [`outcomes`](@ref) for free.
 
 Finally,
 

--- a/src/core/counts.jl
+++ b/src/core/counts.jl
@@ -21,6 +21,11 @@ export is_counting_based
 # because counting is not defined over their outcome spaces (e.g. [`WaveletOverlap`](@ref)
 #  use pre-normalized relative "frequencies", not counts, to estimate probabilities).
 ###########################################################################################
+
+function counts(x)
+    return fasthist!(copy(x))
+end
+
 """
     counts_and_outcomes(o::OutcomeSpace, x) → (cts::Vector{Int}, Ω::Vector)
 
@@ -75,13 +80,14 @@ Like [`allcounts_and_outcomes`](@ref), but only returns the counts.
 """
 allcounts(o::OutcomeSpace, x::Array_or_SSSet) = first(allcounts_and_outcomes(o, x))
 
+# This function must explicitly overriden by count-based `OutcomeSpaces`.
 """
     counts(o::OutcomeSpace, x) → cts::Vector{Int}
 
 Like [`counts_and_outcomes`](@ref), but only returns the counts.
 """
 function counts(o::OutcomeSpace, x)
-    return first(counts_and_outcomes(o, x))
+    throw(ArgumentError("`counts_and_outcomes` not implemented for estimator $(typeof(o))."))
 end
 
 """

--- a/src/core/counts.jl
+++ b/src/core/counts.jl
@@ -80,14 +80,15 @@ Like [`allcounts_and_outcomes`](@ref), but only returns the counts.
 """
 allcounts(o::OutcomeSpace, x::Array_or_SSSet) = first(allcounts_and_outcomes(o, x))
 
-# This function must explicitly overriden by count-based `OutcomeSpaces`.
+# This function *can* be overridden by count-based `OutcomeSpaces` if it is
+# more performant to do so than dispatching to `counts_and_outcomes`.
 """
     counts(o::OutcomeSpace, x) → cts::Vector{Int}
 
 Like [`counts_and_outcomes`](@ref), but only returns the counts.
 """
 function counts(o::OutcomeSpace, x)
-    throw(ArgumentError("`counts` not implemented for estimator $(typeof(o))."))
+    return counts_and_outcomes(o, x)
 end
 
 """

--- a/src/core/counts.jl
+++ b/src/core/counts.jl
@@ -87,7 +87,7 @@ allcounts(o::OutcomeSpace, x::Array_or_SSSet) = first(allcounts_and_outcomes(o, 
 Like [`counts_and_outcomes`](@ref), but only returns the counts.
 """
 function counts(o::OutcomeSpace, x)
-    throw(ArgumentError("`counts_and_outcomes` not implemented for estimator $(typeof(o))."))
+    throw(ArgumentError("`counts` not implemented for estimator $(typeof(o))."))
 end
 
 """

--- a/src/core/counts.jl
+++ b/src/core/counts.jl
@@ -88,7 +88,7 @@ allcounts(o::OutcomeSpace, x::Array_or_SSSet) = first(allcounts_and_outcomes(o, 
 Like [`counts_and_outcomes`](@ref), but only returns the counts.
 """
 function counts(o::OutcomeSpace, x)
-    return counts_and_outcomes(o, x)
+    return first(counts_and_outcomes(o, x))
 end
 
 """

--- a/src/core/probabilities.jl
+++ b/src/core/probabilities.jl
@@ -175,8 +175,13 @@ See also: [`probabilities_and_outcomes`](@ref), [`allprobabilities`](@ref),
 [`allprobabilities_and_outcomes`](@ref), [`Probabilities`](@ref),
 [`ProbabilitiesEstimator`](@ref).
 """
-function probabilities(est, x)
-    return first(probabilities_and_outcomes(est, x))
+function probabilities(o::OutcomeSpace, x)
+    return Probabilities(counts(o, x))
+end
+# The above method is overriden for non-count based outcome spaces. For count-based
+# outcome space, `counts(o::OutcomeSpace, x)` must be defined.
+function probabilities(x)
+    return Probabilities(counts(x))
 end
 
 """

--- a/src/core/probabilities.jl
+++ b/src/core/probabilities.jl
@@ -176,7 +176,11 @@ See also: [`probabilities_and_outcomes`](@ref), [`allprobabilities`](@ref),
 [`ProbabilitiesEstimator`](@ref).
 """
 function probabilities(o::OutcomeSpace, x)
-    return Probabilities(counts(o, x))
+    if is_counting_based(o)
+        return Probabilities(counts(o, x))
+    else
+        return first(probabilities_and_outcomes(o, x))
+    end
 end
 # The above method is overriden for non-count based outcome spaces. For count-based
 # outcome space, `counts(o::OutcomeSpace, x)` must be defined.

--- a/src/encoding_implementations/rectangular_binning.jl
+++ b/src/encoding_implementations/rectangular_binning.jl
@@ -285,10 +285,23 @@ function fasthist(encoder::RectangularBinEncoding, x)
     return hist, bins
 end
 
-# Convenience compatibility with counting api.
-counts(encoder::RectangularBinEncoding, x) = fasthist(encoder, x)
-
 function discard_minus_ones!(bins)
     idxs = findall(isequal(-1), bins)
     deleteat!(bins, idxs)
+end
+
+# ----------------------------------------------------------------
+# Convenience compatibility with counting api.
+# ----------------------------------------------------------------
+function counts(encoding::RectangularBinEncoding, x)
+    cts = first(fasthist(encoding, x))
+    return cts
+end
+
+function counts_and_outcomes(encoding::RectangularBinEncoding, x)
+    cts, bins = fasthist(encoding, x) # bins are integers here
+    unique!(bins) # `bins` is already sorted from `frequencies!`
+    # Here we transform the cartesian coordinate based bins into data unit bins:
+    outcomes = map(b -> decode(encoding, b), bins)
+    return cts, vec(outcomes)
 end

--- a/src/outcome_spaces/count_occurences.jl
+++ b/src/outcome_spaces/count_occurences.jl
@@ -15,7 +15,7 @@ Hence, input `x` is needed for a well-defined [`outcome_space`](@ref).
 struct CountOccurrences <: CountBasedOutcomeSpace end
 
 is_counting_based(o::CountOccurrences) = true
-
+counts(::CountOccurrences, x) = counts(x)
 function counts_and_outcomes(::CountOccurrences, x)
     z = copy(x)
     cts = fasthist!(z)
@@ -25,12 +25,3 @@ end
 
 outcome_space(::CountOccurrences, x) = sort!(unique(x))
 probabilities(::CountOccurrences, x) = probabilities(x)
-counts(::CountOccurrences, x) = counts(x)
-
-function probabilities(x)
-    # Fast histograms code is in the `histograms` folder
-    return Probabilities(counts(x))
-end
-function counts(x)
-    return fasthist!(copy(x))
-end

--- a/src/outcome_spaces/dispersion.jl
+++ b/src/outcome_spaces/dispersion.jl
@@ -87,7 +87,20 @@ function symbolize(est::Dispersion, x)
     return symbols::Vector{Int}
 end
 
+function counts(o::Dispersion, x::AbstractVector{<:Real})
+    return first(counts_and_dispersion_patterns(o, x))
+end
+
 function counts_and_outcomes(o::Dispersion, x::AbstractVector{<:Real})
+    cts, dispersion_patterns = counts_and_dispersion_patterns(o, x)
+    # `dispersion_patterns` is sorted when computing the histogram, so patterns match
+    # the histogram values, but `dispersion_patterns` still contains repeated values,
+    # so we return the unique values.
+    outs = unique(dispersion_patterns)
+    return cts, outs
+end
+
+function counts_and_dispersion_patterns(o::Dispersion, x::AbstractVector{<:Real})
     N = length(x)
     symbols = symbolize(o, x)
     # We must use genembed, not embed, to make sure the zero lag is included
@@ -95,11 +108,8 @@ function counts_and_outcomes(o::Dispersion, x::AbstractVector{<:Real})
     τs = tuple((x for x in 0:-τ:-(m-1)*τ)...)
     dispersion_patterns = genembed(symbols, τs, ones(m))
     cts = fasthist!(dispersion_patterns) # this sorts `dispersion_patterns`
-    # `dispersion_patterns` is sorted when computing the histogram, so patterns match
-    # the histogram values, but `dispersion_patterns` still contains repeated values,
-    # so we return the unique values.
-    outs = unique(dispersion_patterns.data)
-    return cts, outs
+
+    return cts, dispersion_patterns.data
 end
 
 function outcome_space(est::Dispersion)

--- a/src/outcome_spaces/dispersion.jl
+++ b/src/outcome_spaces/dispersion.jl
@@ -96,7 +96,7 @@ function counts_and_outcomes(o::Dispersion, x::AbstractVector{<:Real})
     # `dispersion_patterns` is sorted when computing the histogram, so patterns match
     # the histogram values, but `dispersion_patterns` still contains repeated values,
     # so we return the unique values.
-    outs = unique(dispersion_patterns)
+    outs = unique!(dispersion_patterns)
     return cts, outs
 end
 

--- a/src/outcome_spaces/diversity.jl
+++ b/src/outcome_spaces/diversity.jl
@@ -40,8 +40,8 @@ end
 
 function counts(est::Diversity, x::AbstractVector{T}) where T <: Real
     ds, rbc = similarities_and_binning(est, x)
-    bins = fasthist(rbc, ds)[1]
-    return bins
+    cts = fasthist(rbc, ds)[1]
+    return cts
 end
 
 function counts_and_outcomes(est::Diversity, x::AbstractVector{T}) where T <: Real

--- a/src/outcome_spaces/power_spectrum.jl
+++ b/src/outcome_spaces/power_spectrum.jl
@@ -24,13 +24,15 @@ Input `x` is needed for a well-defined [`outcome_space`](@ref).
 """
 struct PowerSpectrum <: OutcomeSpace end
 
-function probabilities_and_outcomes(est::PowerSpectrum, x)
+function probabilities(est::PowerSpectrum, x)
     @assert x isa AbstractVector{<:Real} "`PowerSpectrum` only works for timeseries input!"
     f = FFTW.rfft(x)
     probs = Probabilities(abs2.(f))
-    events = FFTW.rfftfreq(length(x))
+end
 
-    return probs, events
+function probabilities_and_outcomes(est::PowerSpectrum, x)
+    events = FFTW.rfftfreq(length(x))
+    return probabilities(est, x), events
 end
 
 outcome_space(::PowerSpectrum, x) = FFTW.rfftfreq(length(x))

--- a/src/outcome_spaces/power_spectrum.jl
+++ b/src/outcome_spaces/power_spectrum.jl
@@ -24,15 +24,14 @@ Input `x` is needed for a well-defined [`outcome_space`](@ref).
 """
 struct PowerSpectrum <: OutcomeSpace end
 
-function probabilities(est::PowerSpectrum, x)
-    @assert x isa AbstractVector{<:Real} "`PowerSpectrum` only works for timeseries input!"
+function probabilities_and_outcomes(est::PowerSpectrum, x)
+    if !(x isa AbstractVector{<:Real})
+        throw(ArgumentError("`PowerSpectrum` only works for timeseries input!"))
+    end
     f = FFTW.rfft(x)
     probs = Probabilities(abs2.(f))
-end
-
-function probabilities_and_outcomes(est::PowerSpectrum, x)
     events = FFTW.rfftfreq(length(x))
-    return probabilities(est, x), events
+    return Probabilities(probs), events
 end
 
 outcome_space(::PowerSpectrum, x) = FFTW.rfftfreq(length(x))

--- a/src/outcome_spaces/spatial/spatial_dispersion/SpatialDispersion.jl
+++ b/src/outcome_spaces/spatial/spatial_dispersion/SpatialDispersion.jl
@@ -188,10 +188,6 @@ function counts(est::SpatialDispersion, x::AbstractArray{T, N}) where {T, N}
     return fasthist!(symbols)
 end
 
-function probabilities(est::SpatialDispersion, x::AbstractArray{T, N}) where {T, N}
-    return Probabilities(counts(est, x))
-end
-
 function counts_and_outcomes(est::SpatialDispersion, x::AbstractArray{T, N}) where {T, N}
     symbols = symbol_distribution(est, x)
 

--- a/src/outcome_spaces/spatial/spatial_ordinal/SpatialOrdinalPatterns.jl
+++ b/src/outcome_spaces/spatial/spatial_ordinal/SpatialOrdinalPatterns.jl
@@ -89,13 +89,6 @@ function encoded_space_cardinality(est::SpatialOrdinalPatterns, x::AbstractArray
     return length(s)
 end
 
-probabilities(est::SpatialOrdinalPatterns, x) = Probabilities(counts(est, x))
-function probabilities!(est::SpatialOrdinalPatterns, x, s)
-    s = zeros(Int, length(est.valid))
-    counts!(s, est, x)
-    return Probabilities(counts(s))
-end
-
 function counts(est::SpatialOrdinalPatterns, x)
     s = zeros(Int, length(est.valid))
     counts!(s, est, x)
@@ -119,11 +112,20 @@ function counts_and_outcomes!(s, est::SpatialOrdinalPatterns, x)
     return counts(s), sort!(unique(observed_outcomes))
 end
 
+# Don't use generic dispatch, because we need to use `counts`!.
+function probabilities!(est::SpatialOrdinalPatterns, x, s)
+    s = zeros(Int, length(est.valid))
+    counts!(s, est, x)
+    return Probabilities(counts(s))
+end
+
+# Don't use generic dispatch, because we need to use `counts_and_outcomes`!.
 function probabilities_and_outcomes!(s, est::SpatialOrdinalPatterns, x)
     cts, outs = counts_and_outcomes!(s, est, x)
     return Probabilities(cts), outs
 end
 
+# Don't use generic dispatch, because we need to use `probabilities_and_outcomes`!.
 function probabilities_and_outcomes(est::SpatialOrdinalPatterns, x)
     s = zeros(Int, length(est.valid))
     return probabilities_and_outcomes!(s, est, x)

--- a/src/outcome_spaces/transfer_operator/transfer_operator.jl
+++ b/src/outcome_spaces/transfer_operator/transfer_operator.jl
@@ -440,6 +440,11 @@ function transfermatrix(iv::InvariantMeasure)
     return iv.to.transfermatrix, iv.to.bins
 end
 
+function probabilities(est::TransferOperator, x::Array_or_SSSet)
+    to = transferoperator(StateSpaceSet(x), est.binning)
+    return Probabilities(invariantmeasure(to).ρ)
+end
+
 function probabilities_and_outcomes(est::TransferOperator, x::Array_or_SSSet)
     to = transferoperator(StateSpaceSet(x), est.binning)
     probs = invariantmeasure(to).ρ

--- a/src/outcome_spaces/value_histogram.jl
+++ b/src/outcome_spaces/value_histogram.jl
@@ -48,36 +48,25 @@ An alias for [`ValueHistogram`](@ref).
 """
 const VisitationFrequency = ValueHistogram
 
-# The source code of `ValueHistogram` operates as rather simple calls to
-# the underlying encoding and the `frequencies` function and extensions.
-# See the `rectangular_binning.jl` file for more.
-function probabilities(est::ValueHistogram, x)
-    encoding = RectangularBinEncoding(est.binning, x)
-    Probabilities(fasthist(encoding, x)[1])
-end
-
 outcomes(est::ValueHistogram, x) = last(counts_and_outcomes(est, x))
+
+# --------------------------------------------------------------------------------
+# The source code of `ValueHistogram` operates as rather simple calls to
+# the underlying encoding and the `fasthist`/`fasthist!` functions.
+# See the `encoding_implementations/rectangular_binning.jl` file for more.
+# --------------------------------------------------------------------------------
+function counts(est::ValueHistogram, x)
+    return counts(RectangularBinEncoding(est.binning, x), x)
+end
 
 function counts_and_outcomes(est::ValueHistogram, x)
     encoding = RectangularBinEncoding(est.binning, x)
-    freqs, outcomes = counts_and_outcomes(encoding, x)
-    return freqs, outcomes
+    return counts_and_outcomes(encoding, x)
 end
 
-function counts_and_outcomes(encoding::RectangularBinEncoding, x)
-    freqs, bins = fasthist(encoding, x) # bins are integers here
-    unique!(bins) # `bins` is already sorted from `frequencies!`
-    # Here we transfor the cartesian coordinate based bins into data unit bins:
-    outcomes = map(b -> decode(encoding, b), bins)
-    return freqs, vec(outcomes)
+function outcome_space(est::ValueHistogram, x)
+    return outcome_space(RectangularBinEncoding(est.binning, x))
 end
-
-function probabilities_and_outcomes(encoding::RectangularBinEncoding, x)
-    freqs, outcomes = counts_and_outcomes(encoding, x)
-    return Probabilities(freqs), outcomes
-end
-
-outcome_space(est::ValueHistogram, x) = outcome_space(RectangularBinEncoding(est.binning, x))
 
 function outcome_space(est::ValueHistogram{<:FixedRectangularBinning})
     return outcome_space(RectangularBinEncoding(est.binning))

--- a/src/outcome_spaces/wavelet_overlap.jl
+++ b/src/outcome_spaces/wavelet_overlap.jl
@@ -29,16 +29,12 @@ struct WaveletOverlap{W<:Wavelets.WT.OrthoWaveletClass} <: OutcomeSpace
 end
 WaveletOverlap() = WaveletOverlap(Wavelets.WT.Daubechies{12}())
 
-# RelativeAmount estimation on "pseudo-counts"
-function probabilities(o::WaveletOverlap, x)
-    x isa AbstractVector{<:Real} || error("`WaveletOverlap` only works for timeseries input!")
-    relative_freqs = time_scale_density(x, o.wl)
-    return Probabilities(relative_freqs)
-end
-
 function probabilities_and_outcomes(o::WaveletOverlap, x)
-    probs = probabilities(o, x)
-    return probs, 1:length(probs)
+    if !(x isa AbstractVector{<:Real})
+        throw(ArgumentError("`WaveletOverlap` only works for timeseries input!"))
+    end
+    relative_freqs = time_scale_density(x, o.wl)
+    return Probabilities(relative_freqs), 1:length(relative_freqs)
 end
 
 function outcome_space(::WaveletOverlap, x)

--- a/src/outcome_spaces/wavelet_overlap.jl
+++ b/src/outcome_spaces/wavelet_overlap.jl
@@ -30,10 +30,15 @@ end
 WaveletOverlap() = WaveletOverlap(Wavelets.WT.Daubechies{12}())
 
 # RelativeAmount estimation on "pseudo-counts"
-function probabilities_and_outcomes(est::WaveletOverlap, x)
+function probabilities(o::WaveletOverlap, x)
     x isa AbstractVector{<:Real} || error("`WaveletOverlap` only works for timeseries input!")
-    freqs = time_scale_density(x, est.wl)
-    return Probabilities(freqs), 1:length(freqs)
+    relative_freqs = time_scale_density(x, o.wl)
+    return Probabilities(relative_freqs)
+end
+
+function probabilities_and_outcomes(o::WaveletOverlap, x)
+    probs = probabilities(o, x)
+    return probs, 1:length(probs)
 end
 
 function outcome_space(::WaveletOverlap, x)

--- a/src/probabilities_estimators/Shrinkage.jl
+++ b/src/probabilities_estimators/Shrinkage.jl
@@ -64,7 +64,6 @@ struct Shrinkage{O <: OutcomeSpace, T <: Union{Nothing, Real, Vector{<:Real}}, L
 end
 
 Shrinkage(o::OutcomeSpace; t = nothing, λ = nothing) = Shrinkage(o, t, λ)
-
 function probabilities_and_outcomes(est::Shrinkage, x)
     probs, Ω = probabilities_and_outcomes(est.outcomemodel, x)
     return probs_and_outs_from_histogram(est, probs, Ω, x)

--- a/src/probabilities_estimators/probabilities_estimators.jl
+++ b/src/probabilities_estimators/probabilities_estimators.jl
@@ -6,6 +6,17 @@ function verify_counting_based(o, name = "BayesianRegularization")
     end
 end
 
+# The following methods may be overridden by individual `ProbabilitiesEstimator`s
+# if doing so is more efficient.
+# --------------------------------------------------------------------------------
+function probabilities(est::ProbabilitiesEstimator, x)
+    return first(probabilities_and_outcomes(est, x))
+end
+
+function allprobabilities(est::ProbabilitiesEstimator, x)
+    return first(allprobabilities_and_outcomes(est, x))
+end
+
 include("RelativeAmount.jl")
 include("BayesianRegularization.jl")
 include("Shrinkage.jl")

--- a/test/outcome_spaces/implementations/timescales.jl
+++ b/test/outcome_spaces/implementations/timescales.jl
@@ -7,6 +7,9 @@ using ComplexityMeasures, Test
     x = sin.(t .+  cos.(t/0.1)) .- 0.1;
 
     @testset "WaveletOverlap" begin
+        # Only works for timeseries inputs
+        @test_throws ArgumentError probabilities(WaveletOverlap(), 2)
+
         wl = ComplexityMeasures.Wavelets.WT.Daubechies{4}()
         est = WaveletOverlap(wl)
         ps = probabilities(est, x)
@@ -17,6 +20,9 @@ using ComplexityMeasures, Test
     end
 
     @testset "Fourier Spectrum" begin
+        # Only works for timeseries inputs
+        @test_throws ArgumentError probabilities(PowerSpectrum(), 2)
+
         N = 1000
         t = range(0, 10π, N)
         x = sin.(t)

--- a/test/outcome_spaces/implementations/value_histogram.jl
+++ b/test/outcome_spaces/implementations/value_histogram.jl
@@ -34,7 +34,6 @@ using Random
             est = ValueHistogram(bin)
             out = outcome_space(est, x)
             @test length(out) == n^2
-
             p = probabilities(est, x)
             # all bins are covered due to random data
             @test length(p) == 100


### PR DESCRIPTION
Fixes #297. 

The docs are [here](https://juliadynamics.github.io/ComplexityMeasures.jl/previews/PR305/).


Changes:
- `probabilities` and `probabilities_and_outcomes` generically dispatches to `counts` and `counts_and_outcomes`. 
- Counting-based `OutcomeSpace`s *must* implement `counts` and `counts_and_outcomes`. 
- Non-counting-based `OutcomeSpace`s *must* implement `probabilities` and `probabilities_and_outcomes` (since default dispatch don't work for them).
- Updated devdocs, such that there is one section for adding new `OutcomeSpace`s and one section for adding `ProbabilitiesEstimator`s.