### PR TITLE
Remove `StatsBase` dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,6 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StateSpaceSets = "40b095a5-5852-4c12-98c7-d43bf788e795"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Wavelets = "29a6e085-ba6d-5f35-a997-948ac2efa89a"
 
 [compat]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -17,6 +17,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StateSpaceSets = "40b095a5-5852-4c12-98c7-d43bf788e795"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 TimeseriesSurrogates = "c804724b-8c18-5caa-8579-6025a0767c70"
 


### PR DESCRIPTION
`StatsBase` is needed for the doc build, but not otherwise. This PR moves the dependency on StatsBase from `Project.toml` to `docs/Project.toml`

Closes #307.