### PR TITLE
Minimalistic printing for `Counts` and `Probabilities`

### DIFF
--- a/src/ComplexityMeasures.jl
+++ b/src/ComplexityMeasures.jl
@@ -18,6 +18,7 @@ const Vector_or_SSSet = Union{<:AbstractVector{<:Real}, <:AbstractStateSpaceSet}
 include("core/outcome_spaces.jl")
 include("core/counts.jl")
 include("core/probabilities.jl")
+include("core/print_counts_probs.jl") # pretty printing
 include("core/information_measures.jl")
 include("core/information_functions.jl")
 include("core/encodings.jl")

--- a/src/core/counts.jl
+++ b/src/core/counts.jl
@@ -85,19 +85,6 @@ for f in (:length, :size, :eachindex, :eltype, :parent,
 end
 Base.IteratorSize(::Counts) = Base.HasLength()
 
-# default show used by display() on the REPL
-function Base.show(io::IO, mime::MIME"text/plain", c::Counts)
-    print_dims(io, mime, c.cts, typeof(c))
-end
-
-# Modified from DimensionalData.jl. Controls printing of both
-# `Counts` and `Probabilities`.
-function print_dims(io::IO, mime, dims, T)
-    printstyled(io, "$(T.name.name) "; color=:light_black)
-    ctx = IOContext(io, :inset => " ")
-    return show(ctx, mime, dims)
-end
-
 # We strictly deal with single inputs here. For multi-inputs, see CausalityTools.jl
 """
     counts([o::OutcomeSpace,] x) → cts::Counts

--- a/src/core/print_counts_probs.jl
+++ b/src/core/print_counts_probs.jl
@@ -1,0 +1,41 @@
+# The contents of this file is directly copied from DimensionalData.jl v0.25.2,
+# but modified slightly so that we can reduce the amount of unnecessary printing
+# for `Counts` and `Probabilities`.
+import DimensionalData: NoName
+
+const CountsOrProbs{T, N} = Union{Counts{T, N}, Probabilities{T, N}}
+
+function Base.summary(io::IO, A::CountsOrProbs{T,1}) where {T}
+    print(io, size(A, 1), "-element ")
+    print(io, string(nameof(typeof(A)), "{$T,1}"))
+end
+function Base.summary(io::IO, A::CountsOrProbs{T,N}) where {T,N}
+    print(io, join(size(A), "×"), " ")
+    print(io, string(nameof(typeof(A)), "{$T,$N}"))
+end
+
+function Base.show(io::IO, mime::MIME"text/plain", c::CountsOrProbs)
+    lines = 0
+    if c isa Counts
+        A = c.cts
+    elseif c isa Probabilities
+        A = c.p
+    end
+    summary(io, c)
+    print_name(io, name(c))
+    print("\n")
+
+    # Printing the array data is optional, subtypes can 
+    # show other things here instead.
+    ds = displaysize(io)
+    ioctx = IOContext(io, :displaysize => (ds[1] - lines, ds[2]))
+    DimensionalData.show_after(ioctx, mime, A)
+    return nothing
+end
+
+# print a name of something, in yellow
+function print_name(io::IO, name)
+    if !(name == Symbol("") || name isa NoName)
+        printstyled(io, string(" ", name); color=:yellow)
+    end
+end

--- a/src/core/probabilities.jl
+++ b/src/core/probabilities.jl
@@ -69,11 +69,6 @@ function Probabilities(x::AbstractArray{<:Integer, N}) where N
 end
 Probabilities(x::Counts) = Probabilities(x.cts, x.cts.dims)
 
-# default show used by display() on the REPL
-function Base.show(io::IO, mime::MIME"text/plain", p::Probabilities)
-    print_dims(io, mime, p.p, typeof(p))
-end
-
 # extend DimensionalData interface:
 for f in (:dims, :refdims, :data, :name, :metadata, :layerdims)
     @eval $(f)(c::Probabilities) = $(f)(c.p)


### PR DESCRIPTION
CC @Datseris,

This makes the printing of `Counts` and `Probabilities` much more minimalistic (ref discussion in #316). 