### PR TITLE
Reproducibility for `TransferOperator`

### DIFF
--- a/test/outcome_spaces/implementations/transfer_operator.jl
+++ b/test/outcome_spaces/implementations/transfer_operator.jl
@@ -45,3 +45,18 @@ end
 imprecise_warning = "`binning.precise == false`. You may be getting points outside the binning."
 b = RectangularBinning(5)
 @test_logs (:warn, imprecise_warning) ComplexityMeasures.transferoperator(D, b; warn_precise = true)
+
+# ---------------
+# Reproducibility
+# ---------------
+
+# Resetting rng will lead to identical results.
+p1 = probabilities(TransferOperator(b; rng = MersenneTwister(1234)), D)
+p2 = probabilities(TransferOperator(b; rng = MersenneTwister(1234)), D)
+@test all(p1 .== p2)
+
+# Not resetting rng will lead to non-identical results.
+rng = MersenneTwister(1234)
+p1 = probabilities(TransferOperator(b; rng), D)
+p2 = probabilities(TransferOperator(b; rng), D)
+@test !all(p1 .== p2)

--- a/test/outcome_spaces/implementations/transfer_operator.jl
+++ b/test/outcome_spaces/implementations/transfer_operator.jl
@@ -60,3 +60,4 @@ rng = MersenneTwister(1234)
 p1 = probabilities(TransferOperator(b; rng), D)
 p2 = probabilities(TransferOperator(b; rng), D)
 @test !all(p1 .== p2)
+@test p1[1] ≈ p2[1] # But we should be close


### PR DESCRIPTION
Background in #337. Fixes #339.

## Changes

- Added `rng` argument to `TransferOperator` and underlying functions. 

## Example

```julia
# Resetting rng will lead to identical results.
p1 = probabilities(TransferOperator(b; rng = MersenneTwister(1234)), D)
p2 = probabilities(TransferOperator(b; rng = MersenneTwister(1234)), D)
@test all(p1 .== p2) # true

# Not resetting rng will lead to non-identical results.
rng = MersenneTwister(1234)
p1 = probabilities(TransferOperator(b; rng), D)
p2 = probabilities(TransferOperator(b; rng), D)
@test !all(p1 .== p2) # true
@test p1[1] ≈ p2[1] # true, since estimates are close
```