### PR TITLE
Refactoring and fixes for the `tutorial` branch

### DIFF
--- a/docs/src/devdocs.md
+++ b/docs/src/devdocs.md
@@ -67,9 +67,8 @@ leads to performance benefits.
 3. Implement dispatch for [`probabilities`](@ref) for your
     [`ProbabilitiesEstimator`](@ref) type. You'll then get
     [`probabilities_and_outcomes`](@ref) for free.
-4. Implement dispatch for [`allprobabilities`](@ref) for your
-    [`ProbabilitiesEstimator`](@ref) type. You'll then get
-    [`allprobabilities_and_outcomes`](@ref) for free.
+4. Implement dispatch for [`allprobabilities_and_outcomes`](@ref) for your
+    [`ProbabilitiesEstimator`](@ref) type. 
 5. Add your new [`ProbabilitiesEstimator`](@ref) type to the list of probabilities
     estimators in the probabilities estimators documentation section.
 

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -30,7 +30,7 @@ fig
 
 In this example we show how simple it is to compute the [KL-divergence](https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence) (or any other distance function for probability distributions) using ComplexityMeasures.jl. For simplicity, we will compute the KL-divergence between the [`ValueBinning`](@ref)s of two timeseries.
 
-Note that it is **crucial** to use [`allprobabilities`](@ref) instead of [`probabilities`](@ref).
+Note that it is **crucial** to use [`allprobabilities_and_outcomes`](@ref) instead of [`probabilities_and_outcomes`](@ref).
 
 ```@example MAIN
 using ComplexityMeasures
@@ -42,8 +42,8 @@ y = @. sin(t + cos(2t))
 
 r = -1:0.1:1
 est = ValueBinning(FixedRectangularBinning(r))
-px = allprobabilities(est, x)
-py = allprobabilities(est, y)
+px, outsx = allprobabilities_and_outcomes(est, x)
+py, outsy = allprobabilities_and_outcomes(est, y)
 
 # Visualize
 using CairoMakie

--- a/docs/src/probabilities.md
+++ b/docs/src/probabilities.md
@@ -101,7 +101,6 @@ probabilities
 probabilities_and_outcomes
 allprobabilities_and_outcomes
 probabilities!
-allprobabilities
 ```
 
 ## Counts
@@ -111,7 +110,6 @@ Counts
 counts_and_outcomes
 counts
 allcounts_and_outcomes
-allcounts
 is_counting_based
 ```
 

--- a/docs/src/tutorial.jl
+++ b/docs/src/tutorial.jl
@@ -140,9 +140,10 @@ probsx = probabilities(o, x)
 # that are not in the data are skipped. This can save memory for outcome
 # spaces with large numbers of outcomes.
 # To explicitly obtain all outcomes, by assigning 0 probability to not encountered outcomes,
-# use [`allprobabilities`](@ref) or [`allprobabilities_and_outcomes`](@ref).
+# use [`allprobabilities_and_outcomes`](@ref).
 # For [`OrdinalPatterns`](@ref) the outcome space does not depend on input data and is
-# always the same. Hence, the corresponding outcomes matching to [`allprobabilities`](@ref),
+# always the same. Hence, the corresponding outcomes matching to 
+# [`allprobabilities_and_outcomes`](@ref),
 # coincide for `x` and `y`, and also coincide with the output of the function
 # [`outcome_space`](@ref):
 

--- a/docs/src/tutorial.jl
+++ b/docs/src/tutorial.jl
@@ -201,15 +201,15 @@ probsy_bayes .- probsy
 # Shannon entropy of the probabilities `probsy` we computed above based on ordinal patterns.
 # To compute it, we use the [`entropy`](@ref) function.
 
-perm_ent_x = entropy(OrdinalPatterns(), x)
-perm_ent_y = entropy(OrdinalPatterns(), y)
+perm_ent_x = entropy(Shannon(), OrdinalPatterns(), x)
+perm_ent_y = entropy(Shannon(), OrdinalPatterns(), y)
 (perm_ent_x, perm_ent_y)
 
 # As expected, the permutation entropy of the `x` signal is higher, because the signal is
 # "more random". Moreover, since we have estimated the probabilities already, we could
 # have passed these to the entropy function directly instead of recomputing them as above
 
-perm_ent_y_2 = entropy(probsy)
+perm_ent_y_2 = entropy(Shannon(), probsy)
 
 # We crucially realize here that many quantities in the NLTS literature that
 # are named as entropies, such as "permutation entropy", are _not really new entropies_.

--- a/docs/src/tutorial.jl
+++ b/docs/src/tutorial.jl
@@ -201,15 +201,15 @@ probsy_bayes .- probsy
 # Shannon entropy of the probabilities `probsy` we computed above based on ordinal patterns.
 # To compute it, we use the [`entropy`](@ref) function.
 
-perm_ent_x = entropy(Shannon(), OrdinalPatterns(), x)
-perm_ent_y = entropy(Shannon(), OrdinalPatterns(), y)
+perm_ent_x = entropy(OrdinalPatterns(), x)
+perm_ent_y = entropy(OrdinalPatterns(), y)
 (perm_ent_x, perm_ent_y)
 
 # As expected, the permutation entropy of the `x` signal is higher, because the signal is
 # "more random". Moreover, since we have estimated the probabilities already, we could
 # have passed these to the entropy function directly instead of recomputing them as above
 
-perm_ent_y_2 = entropy(Shannon(), probsy)
+perm_ent_y_2 = entropy(probsy)
 
 # We crucially realize here that many quantities in the NLTS literature that
 # are named as entropies, such as "permutation entropy", are _not really new entropies_.

--- a/src/core/counts.jl
+++ b/src/core/counts.jl
@@ -3,7 +3,7 @@ import Base.unique!
 
 export Counts
 export counts, counts_and_outcomes
-export allcounts, allcounts_and_outcomes
+export allcounts_and_outcomes
 export is_counting_based
 
 ###########################################################################################
@@ -196,9 +196,6 @@ Like [`counts_and_outcomes`](@ref), but ensures that *all* outcomes `Ωᵢ ∈ �
 where `Ω = outcome_space(o, x)`), are included.
 
 Outcomes that do not occur in the data `x` get a 0 count.
-
-If you don't need the decoded outcomes, it may be more efficient to use 
-[`allcounts`](@ref) instead.
 """
 function allcounts_and_outcomes(o::OutcomeSpace, x::Array_or_SSSet)
     cts, outs = counts_and_outcomes(o, x)

--- a/src/core/counts.jl
+++ b/src/core/counts.jl
@@ -3,7 +3,7 @@ import Base.unique!
 
 export Counts
 export counts, counts_and_outcomes
-export allcounts
+export allcounts, allcounts_and_outcomes
 export is_counting_based
 
 ###########################################################################################
@@ -215,6 +215,13 @@ function allcounts_and_outcomes(o::OutcomeSpace, x::Array_or_SSSet)
     c = Counts(allcts, (ospace,), (:x1, ))
     return c, outcomes(c)
 end
+
+"""
+    allcounts(o::OutcomeSpace, x::Array_or_SSSet) → cts::Counts
+
+Like [`allcounts_and_outcomes`](@ref), but returns only the [`Counts`](@ref).
+"""
+allcounts(o::OutcomeSpace, x) = first(allcounts_and_outcomes(o, x))
 
 """
     is_counting_based(o::OutcomeSpace)

--- a/src/core/counts.jl
+++ b/src/core/counts.jl
@@ -217,13 +217,6 @@ function allcounts_and_outcomes(o::OutcomeSpace, x::Array_or_SSSet)
 end
 
 """
-    allcounts(o::OutcomeSpace, x::Array_or_SSSet) → cts::Counts
-
-Like [`allcounts_and_outcomes`](@ref), but returns only the [`Counts`](@ref).
-"""
-allcounts(o::OutcomeSpace, x) = first(allcounts_and_outcomes(o, x))
-
-"""
     is_counting_based(o::OutcomeSpace)
 
 Return `true` if the [`OutcomeSpace`](@ref) `o` is counting-based, and `false` otherwise.

--- a/src/core/counts.jl
+++ b/src/core/counts.jl
@@ -174,8 +174,6 @@ function counts_and_outcomes(o::OutcomeSpace, x)
     end
 end
 
-
-
 # -----------------------------------------------------------------
 # Outcomes are simply the labels on the marginal dimensional.
 # For 1D, we return the outcomes as-is. For ND, we return
@@ -197,13 +195,17 @@ function outcomes(c::Counts{<:Integer, N}, idxs) where N
 end
 
 """
-    allcounts(o::OutcomeSpace, x::Array_or_SSSet) → cts::Counts{<:Integer, 1}
+    allcounts_and_outcomes(o::OutcomeSpace, x::Array_or_SSSet) → cts::Counts{<:Integer, 1}
 
-Like [`counts`](@ref), but ensures that *all* outcomes `Ωᵢ ∈ Ω`,
+Like [`counts_and_outcomes`](@ref), but ensures that *all* outcomes `Ωᵢ ∈ Ω`,
 where `Ω = outcome_space(o, x)`), are included.
-Outcomes that do not occur in the data `x` get 0 count.
+
+Outcomes that do not occur in the data `x` get a 0 count.
+
+If you don't need the decoded outcomes, it may be more efficient to use 
+[`allcounts`](@ref) instead.
 """
-function allcounts(o::OutcomeSpace, x::Array_or_SSSet)
+function allcounts_and_outcomes(o::OutcomeSpace, x::Array_or_SSSet)
     cts, outs = counts_and_outcomes(o, x)
     outs = outcomes(cts)
     ospace = vec(outcome_space(o, x))
@@ -215,7 +217,8 @@ function allcounts(o::OutcomeSpace, x::Array_or_SSSet)
             allcts[i] = cts[idx]
         end
     end
-    return Counts(allcts, (ospace,), (:x1, ))
+    c = Counts(allcts, (ospace,), (:x1, ))
+    return c, outcomes(c)
 end
 
 """

--- a/src/core/information_functions.jl
+++ b/src/core/information_functions.jl
@@ -92,6 +92,9 @@ j_r = information(Jackknife(RenyiExtropy()), RelativeAmount(),  x)
 function information(e::InformationMeasure, o::OutcomeSpace, x)
     return information(PlugIn(e), RelativeAmount(), o, x)
 end
+function information(est::ProbabilitiesEstimator, o::OutcomeSpace, x)
+    return information(PlugIn(Shannon()), est, o, x)
+end
 function information(e::InformationMeasure, est::ProbabilitiesEstimator, o::OutcomeSpace, x)
     return information(PlugIn(e), est, o, x)
 end

--- a/src/core/information_functions.jl
+++ b/src/core/information_functions.jl
@@ -129,6 +129,9 @@ function entropy(args...)
     elseif e isa InformationMeasureEstimator
         # Estimator is for any subtype of entropy
         e.definition isa Entropy
+    elseif e isa Probabilities
+        # Default to Shannon entropy if no information measure is given
+        return information(Shannon(), args...)
     else
         false
     end

--- a/src/core/outcome_spaces.jl
+++ b/src/core/outcome_spaces.jl
@@ -46,12 +46,13 @@ In the column "input data" it is assumed that the `eltype` of the input is `<: R
 
 Outcome spaces are used as input to
 
-- [`probabilities`](@ref)/[`allprobabilities`](@ref) for computing probability
-    mass functions.
+- [`probabilities`](@ref)/[`allprobabilities_and_outcomes`](@ref) for computing
+    probability mass functions.
 - [`outcome_space`](@ref), which returns the elements of the outcome space.
 - [`total_outcomes`](@ref), which returns the cardinality of the outcome space.
-- [`counts`](@ref)/[`allcounts`](@ref), for obtaining raw counts instead
-    of probabilities (only for counting-compatible outcome spaces).
+- [`counts`](@ref)/[`counts_and_outcomes`](@ref)/[`allcounts_and_outcomes`](@ref), for 
+    obtaining raw counts instead of probabilities (only for counting-compatible outcome
+    spaces).
 
 ## Counting-compatible vs. non-counting compatible outcome spaces
 

--- a/src/core/probabilities.jl
+++ b/src/core/probabilities.jl
@@ -281,8 +281,8 @@ end
 # Each `ProbabilitiesEstimator` subtype must extend this method explicitly.
 
 """
-    allprobabilities_and_outcomes(est::ProbabilitiesEstimator, x::Array_or_SSSet) → p
-    allprobabilities_and_outcomes(o::OutcomeSpace, x::Array_or_SSSet) → p
+    allprobabilities_and_outcomes(est::ProbabilitiesEstimator, x::Array_or_SSSet) → (p::Probabilities, outs)
+    allprobabilities_and_outcomes(o::OutcomeSpace, x::Array_or_SSSet) → (p::Probabilities, outs)
 
 The same as [`probabilities_and_outcomes`](@ref), but ensures that outcomes with `0`
 probability are explicitly added in the returned vector. This means that `p[i]` is the
@@ -341,6 +341,14 @@ function allprobabilities(est::ProbabilitiesEstimator, o::OutcomeSpace, x)
     p, outs = allprobabilities_and_outcomes(est, o, x)
     return p
 end
+
+"""
+    allprobabilities(est::ProbabilitiesEstimator, x::Array_or_SSSet) → p::Probabilities
+    allprobabilities(o::OutcomeSpace, x::Array_or_SSSet) → p::Probabilities
+
+Like [`allprobabilities_and_outcomes`](@ref), but returns only the probabilities.
+"""
+function allprobabilities end
 allprobabilities(o::OutcomeSpace, x) = allprobabilities(RelativeAmount(), o, x)
 
 """

--- a/src/core/probabilities.jl
+++ b/src/core/probabilities.jl
@@ -2,7 +2,6 @@
 export ProbabilitiesEstimator, Probabilities
 export probabilities, probabilities!
 export probabilities_and_outcomes
-export allprobabilities
 export allprobabilities_and_outcomes
 export missing_outcomes
 
@@ -131,7 +130,8 @@ space with known cardinality. Therefore, `ProbabilitiesEstimator` accept an
 [`OutcomeSpace`](@ref) as the first
 argument, which specifies the set of possible outcomes.
 
-Probabilities estimators are used with [`probabilities`](@ref) and [`allprobabilities`](@ref).
+Probabilities estimators are used with [`probabilities`](@ref) and
+[`allprobabilities_and_outcomes`](@ref).
 
 ## Implementations
 
@@ -292,7 +292,7 @@ This function is useful in cases where one wants to compare the probability mass
 of two different input data `x, y` under the same estimator. E.g., to compute the
 KL-divergence of the two PMFs assumes that the obey the same indexing. This is
 not true for [`probabilities`](@ref) even with the same `est`, due to the skipping
-of 0 entries, but it is true for [`allprobabilities`](@ref).
+of 0 entries, but it is true for [`allprobabilities_and_outcomes`](@ref).
 """
 function allprobabilities_and_outcomes(est::ProbabilitiesEstimator, o::OutcomeSpace, x)
     # the observed outcomes and their probabilities
@@ -349,7 +349,7 @@ Count the number of missing (i.e., zero-probability) outcomes
 specified by `o`, given input data `x`, using [`RelativeAmount`](@ref)
 probabilities estimation.
 
-If `all == true`, then [`allprobabilities`](@ref) is used to compute the probabilities.
+If `all == true`, then [`allprobabilities_and_outcomes`](@ref) is used to compute the probabilities.
 If `all == false`, then [`probabilities`](@ref) is used to compute the probabilities.
 
 This is syntactically equivalent to `missing_outcomes(RelativeAmount(o), x)`.

--- a/src/core/probabilities.jl
+++ b/src/core/probabilities.jl
@@ -343,15 +343,6 @@ function allprobabilities(est::ProbabilitiesEstimator, o::OutcomeSpace, x)
 end
 
 """
-    allprobabilities(est::ProbabilitiesEstimator, x::Array_or_SSSet) → p::Probabilities
-    allprobabilities(o::OutcomeSpace, x::Array_or_SSSet) → p::Probabilities
-
-Like [`allprobabilities_and_outcomes`](@ref), but returns only the probabilities.
-"""
-function allprobabilities end
-allprobabilities(o::OutcomeSpace, x) = allprobabilities(RelativeAmount(), o, x)
-
-"""
     missing_outcomes(o::OutcomeSpace, x; all = true) → n_missing::Int
 
 Count the number of missing (i.e., zero-probability) outcomes

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -113,11 +113,13 @@ function AmplitudeAwareOrdinalPatterns(; A = 0.5, τ::Int = 1, m::Int = 3, lt::F
 end
 
 # For 3.0
+export allprobabilities
 function allprobabilities(args...)
     @warn "`allprobabilities` is deprecated. Use `allprobabilities_and_outcomes` instead."
     return first(allprobabilities_and_outcomes(args...))
 end
 
+export allcounts
 function allcounts(args...)
     @warn "`allcounts` is deprecated. Use `allcounts_and_outcomes` instead."
     return first(allcounts_and_outcomes(args...))

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -111,3 +111,14 @@ function AmplitudeAwareOrdinalPatterns(; A = 0.5, τ::Int = 1, m::Int = 3, lt::F
     m >= 2 || throw(ArgumentError("Need order m ≥ 2."))
     return AmplitudeAwareOrdinalPatterns{m, F}(OrdinalPatternEncoding{m}(lt), τ, A)
 end
+
+# For 3.0
+function allprobabilities(args...)
+    @warn "`allprobabilities` is deprecated. Use `allprobabilities_and_outcomes` instead."
+    return first(allprobabilities_and_outcomes(args...))
+end
+
+function allcounts(args...)
+    @warn "`allcounts` is deprecated. Use `allcounts_and_outcomes` instead."
+    return first(allcounts_and_outcomes(args...))
+end

--- a/src/probabilities_estimators/AddConstant.jl
+++ b/src/probabilities_estimators/AddConstant.jl
@@ -43,19 +43,21 @@ struct AddConstant{A} <: ProbabilitiesEstimator
     end
 end
 
-function probabilities(est::AddConstant, outcomemodel::OutcomeSpace, x)
+function probabilities_and_outcomes(est::AddConstant, outcomemodel::OutcomeSpace, x)
     verify_counting_based(outcomemodel, "AddConstant")
 
     cts, outs = counts_and_outcomes(outcomemodel, x)
-    return probs_and_outs_from_histogram(est, outcomemodel, cts, outs, x)
+    p = probs_and_outs_from_histogram(est, outcomemodel, cts, outs, x)
+    return p, outcomes(p)
 end
 
 # Assigns non-zero probability to unobserved outcomes.
-function allprobabilities(est::AddConstant, outcomemodel::OutcomeSpace, x)
+function allprobabilities_and_outcomes(est::AddConstant, outcomemodel::OutcomeSpace, x)
     verify_counting_based(outcomemodel, "AddConstant")
 
     cts, outs = allcounts_and_outcomes(outcomemodel, x)
-    return probs_and_outs_from_histogram(est, outcomemodel, cts, outs, x)
+    p = probs_and_outs_from_histogram(est, outcomemodel, cts, outs, x)
+    return p, outcomes(p)
 end
 
 # Only defined for 1D pmfs.

--- a/src/probabilities_estimators/AddConstant.jl
+++ b/src/probabilities_estimators/AddConstant.jl
@@ -22,16 +22,15 @@ where ``m`` is the cardinality of the outcome space, and ``n`` is the number of
 (encoded) input data points, and ``n_k`` is the number of times the outcome ``\\omega_{k}``
 is observed in the (encoded) input data points.
 
-If the `AddConstant` estimator used with
-[`probabilities`](@ref)/[`probabilities_and_outcomes`](@ref),
+If the `AddConstant` estimator used with [`probabilities_and_outcomes`](@ref),
 then ``m`` is set to the number of *observed* outcomes. If used with
-[`allprobabilities`](@ref)/[`allprobabilities_and_outcomes`](@ref), then ``m`` is set to
+[`allprobabilities_and_outcomes`](@ref), then ``m`` is set to
 the number of *possible* outcomes.
 
 !!! note "Unobserved outcomes are assigned nonzero probability!"
     Looking at the formula above, if ``n_k = 0``, then unobserved outcomes are assigned
     a non-zero probability of ``\\dfrac{c}{n + mc}``. This means that if the estimator
-    is used with [`allprobabilities`](@ref)/[`allprobabilities_and_outcomes`](@ref), then
+    is used with [`allprobabilities_and_outcomes`](@ref), then
     all outcomes, even those that are not observed, are assigned non-zero probabilities.
     This might affect your results if using e.g. [`missing_outcomes`](@ref).
 """

--- a/src/probabilities_estimators/BayesianRegularization.jl
+++ b/src/probabilities_estimators/BayesianRegularization.jl
@@ -35,7 +35,8 @@ There are many common choices of priors, some of which are listed in
 - `a == 1` (BayesianRegularization-Laplace uniform prior)
 
 `a` can also be chosen as a vector of real numbers. Then, if used with
-[`allprobabilities`](@ref), it is required that `length(a) == total_outcomes(o, x)`,
+[`allprobabilities_and_outcomes`](@ref), it is required that 
+`length(a) == total_outcomes(o, x)`,
 where `x` is the input data and `o` is the [`OutcomeSpace`](@ref).
 If used with [`probabilities`](@ref), then `length(a)` must match the number of
 *observed* outcomes (you can check this using [`probabilities_and_outcomes`](@ref)).
@@ -46,14 +47,15 @@ and the errors depend both on the choice of `a` and on the sampling scenario
 ## Assumptions
 
 The `BayesianRegularization` estimator assumes a fixed and known `m`. Thus, using it with
-[`probabilities`](@ref) and [`allprobabilities`](@ref) will yield different results,
+[`probabilities_and_outcomes`](@ref) and [`allprobabilities_and_outcomes`](@ref) will 
+yield different results,
 depending on whether all outcomes are observed in the input data or not.
-For [`probabilities`](@ref), `m` is the number of *observed* outcomes.
-For [`allprobabilities`](@ref), `m = total_outcomes(o, x)`, where `o` is the
+For [`probabilities_and_outcomes`](@ref), `m` is the number of *observed* outcomes.
+For [`allprobabilities_and_outcomes`](@ref), `m = total_outcomes(o, x)`, where `o` is the
 [`OutcomeSpace`](@ref) and `x` is the input data.
 
 !!! note
-    If used with [`allprobabilities`](@ref)/[`allprobabilities_and_outcomes`](@ref), then
+    If used with [`allprobabilities_and_outcomes`](@ref), then
     outcomes which have not been observed may be assigned non-zero probabilities.
     This might affect your results if using e.g. [`missing_outcomes`](@ref).
 

--- a/src/probabilities_estimators/BayesianRegularization.jl
+++ b/src/probabilities_estimators/BayesianRegularization.jl
@@ -74,11 +74,11 @@ struct BayesianRegularization{A} <: ProbabilitiesEstimator
     end
 end
 
-# We need to implement `probabilities_and_outcomes` and `allprobabilities` separately,
+# We need to implement `probabilities_and_outcomes` and `allprobabilities_and_outcomes` separately,
 # because the number of elements in the outcome space determines the factor `A`, since
 # A = sum(aₖ). Explicitly modelling the entire outcome space, instead of considering
 # only the observed outcomes, will therefore affect the estimated probabilities.
-function probabilities(est::BayesianRegularization, outcomemodel::OutcomeSpace, x)
+function probabilities_and_outcomes(est::BayesianRegularization, outcomemodel::OutcomeSpace, x)
     verify_counting_based(outcomemodel, "BayesianRegularization")
 
     a = est.a
@@ -103,10 +103,11 @@ function probabilities(est::BayesianRegularization, outcomemodel::OutcomeSpace, 
         aₖ = get_aₖ_bayes(a, i)
         probs[i] = θ̂bayes(yᵢ, aₖ, n, A)
     end
-    return Probabilities(probs, observed_outcomes)
+    p = Probabilities(probs, observed_outcomes)
+    return p, outcomes(p)
 end
 
-function allprobabilities(est::BayesianRegularization, outcomemodel::OutcomeSpace, x)
+function allprobabilities_and_outcomes(est::BayesianRegularization, outcomemodel::OutcomeSpace, x)
     verify_counting_based(outcomemodel, "BayesianRegularization")
 
     a = est.a
@@ -133,8 +134,8 @@ function allprobabilities(est::BayesianRegularization, outcomemodel::OutcomeSpac
         aₖ = get_aₖ_bayes(a, i)
         probs[idx] = θ̂bayes(yᵢ, aₖ, n, A)
     end
-
-    return Probabilities(probs, Ω)
+    p = Probabilities(probs, Ω)
+    return p, outcomes(p)
 end
 
 get_aₖ_bayes(a, i) = a isa Real ? a : a[i]

--- a/src/probabilities_estimators/BayesianRegularization.jl
+++ b/src/probabilities_estimators/BayesianRegularization.jl
@@ -64,7 +64,7 @@ For [`allprobabilities_and_outcomes`](@ref), `m = total_outcomes(o, x)`, where `
 ```julia
 using ComplexityMeasures
 x = cumsum(randn(100))
-ps_bayes = probabilities(BayesianRegularization(a = 0.5), OrdinalPatterns(m = 3), x)
+ps_bayes = probabilities(BayesianRegularization(a = 0.5), OrdinalPatterns{3}(), x)
 ```
 
 See also: [`RelativeAmount`](@ref), [`Shrinkage`](@ref).

--- a/src/probabilities_estimators/RelativeAmount.jl
+++ b/src/probabilities_estimators/RelativeAmount.jl
@@ -2,7 +2,7 @@ export RelativeAmount
 
 """
     RelativeAmount <: ProbabilitiesEstimator
-    RelativeAmount(o::OutcomeSpace)
+    RelativeAmount()
 
 The `RelativeAmount` estimator is used with [`probabilities`](@ref) and related functions to estimate
 probabilities over the given [`OutcomeSpace`](@ref) using maximum likelihood estimation

--- a/src/probabilities_estimators/RelativeAmount.jl
+++ b/src/probabilities_estimators/RelativeAmount.jl
@@ -31,8 +31,8 @@ Hence, this estimator is called `RelativeAmount`.
 ```julia
 using ComplexityMeasures
 x = cumsum(randn(100))
-ps = probabilities(SymbolicPermutation(m = 3), x) # `RelativeAmount` is the default estimator
-ps_mle = probabilities(RelativeAmount(), SymbolicPermutation(m = 3), x) # equivalent
+ps = probabilities(OrdinalPatterns{3}(), x) # `RelativeAmount` is the default estimator
+ps_mle = probabilities(RelativeAmount(), OrdinalPatterns{3}(), x) # equivalent
 ps == ps_mle # true
 ```
 

--- a/src/probabilities_estimators/Shrinkage.jl
+++ b/src/probabilities_estimators/Shrinkage.jl
@@ -61,12 +61,12 @@ struct Shrinkage{T <: Union{Nothing, Real, Vector{<:Real}}, L <: Union{Nothing, 
     end
 end
 
-function probabilities(est::Shrinkage, outcomemodel::OutcomeSpace, x)
+function probabilities_and_outcomes(est::Shrinkage, outcomemodel::OutcomeSpace, x)
     probs, Ω = probabilities_and_outcomes(RelativeAmount(), outcomemodel, x)
     return probs_and_outs_from_histogram(est, outcomemodel, probs, Ω, x)
 end
 
-function allprobabilities(est::Shrinkage, outcomemodel::OutcomeSpace, x)
+function allprobabilities_and_outcomes(est::Shrinkage, outcomemodel::OutcomeSpace, x)
     probs_all, Ω_all = allprobabilities_and_outcomes(outcomemodel, x)
     return probs_and_outs_from_histogram(est, outcomemodel, probs_all, Ω_all, x)
 end
@@ -93,7 +93,8 @@ function probs_and_outs_from_histogram(est::Shrinkage, outcomemodel::OutcomeSpac
         probs[idx] = θₖ_shrink(probs_observed[k], λ, tₖ)
     end
     @assert sum(probs) ≈ 1.0
-    return Probabilities(probs, Ω_observed,)
+    p = Probabilities(probs, Ω_observed,)
+    return p, outcomes(p)
 end
 
 function get_λ(est, n, probs_observed, t, m)

--- a/src/probabilities_estimators/Shrinkage.jl
+++ b/src/probabilities_estimators/Shrinkage.jl
@@ -1,6 +1,5 @@
 export Shrinkage
 
-# TODO: make sure we act correctly for `probabilities` and `allprobabilities`.
 """
     Shrinkage{<:OutcomeSpace} <: ProbabilitiesEstimator
     Shrinkage(; t = nothing, λ = nothing)
@@ -32,14 +31,15 @@ to [Hausser2009](@citet). Hence, you should probably not pick
 ## Assumptions
 
 The `Shrinkage` estimator assumes a fixed and known number of outcomes `m`. Thus, using
-it with [`probabilities`](@ref) and [`allprobabilities`](@ref) will yield different results,
+it with [`probabilities_and_outcomes`](@ref)) and 
+[`allprobabilities_and_outcomes`](@ref) will yield different results,
 depending on whether all outcomes are observed in the input data or not.
-For [`probabilities`](@ref), `m` is the number of *observed* outcomes.
-For [`allprobabilities`](@ref), `m = total_outcomes(o, x)`, where `o` is the
+For [`probabilities_and_outcomes`](@ref), `m` is the number of *observed* outcomes.
+For [`allprobabilities_and_outcomes`](@ref), `m = total_outcomes(o, x)`, where `o` is the
 [`OutcomeSpace`](@ref) and `x` is the input data.
 
 !!! note
-    If used with [`allprobabilities`](@ref), then
+    If used with [`allprobabilities_and_outcomes`](@ref), then
     outcomes which have not been observed may be assigned non-zero probabilities.
     This might affect your results if using e.g. [`missing_outcomes`](@ref).
 
@@ -48,7 +48,7 @@ For [`allprobabilities`](@ref), `m = total_outcomes(o, x)`, where `o` is the
 ```julia
 using ComplexityMeasures
 x = cumsum(randn(100))
-ps_shrink = probabilities(Shrinkage(OrdinalPatterns(m = 3)), x)
+ps_shrink = probabilities(Shrinkage(), OrdinalPatterns{3}(), x)
 ```
 
 See also: [`RelativeAmount`](@ref), [`BayesianRegularization`](@ref).

--- a/test/convenience.jl
+++ b/test/convenience.jl
@@ -4,7 +4,7 @@ using Random
 rng = Xoshiro(1234)
 
 @testset "Common literature names" begin
-    x = randn(1000)
+    x = randn(rng, 1000)
 
     @test entropy_permutation(x) == information(OrdinalPatterns(), x)
     @test entropy_wavelet(x) == information(WaveletOverlap(), x)
@@ -21,5 +21,15 @@ end
 
 @testset "entropy convenience function" begin
     p = Probabilities(rand(rng, 100))
+    x = rand(rng, 100)
+    o = OrdinalPatterns{3}()
+    pest = RelativeAmount()
+    e = Shannon()
+    hest = Jackknife(e)
+
     @test entropy(p) == information(Shannon(), p)
+    @test entropy(o, x) == information(o, x)
+    @test entropy(pest, o, x) == information(pest, o, x) == information(PlugIn(Shannon()), o, x)
+    @test entropy(e, pest, o, x) == information(PlugIn(e), pest, o, x)
+    @test entropy(hest, pest, o, x) == information(hest, pest, o, x)
 end

--- a/test/convenience.jl
+++ b/test/convenience.jl
@@ -1,5 +1,7 @@
 using ComplexityMeasures
 using Test
+using Random
+rng = Xoshiro(1234)
 
 @testset "Common literature names" begin
     x = randn(1000)
@@ -15,4 +17,9 @@ end
 @testset "probabilities(x)" begin
     x = [1, 1, 2, 2, 3, 3]
     @test probabilities(x) == probabilities(UniqueElements(), x) == [1/3, 1/3, 1/3]
+end
+
+@testset "entropy convenience function" begin
+    p = Probabilities(rand(rng, 100))
+    @test entropy(p) == information(Shannon(), p)
 end


### PR DESCRIPTION
Some necessary changes to get #347 to pass CI and adhere to API.

- `probabilities_and_outcomes` and `allprobabilities_and_outcomes` are consistently the methods implemented, and `probabilities`/`allprobabilities` are just calls to those functions. The exception is if implementing the latter methods is faster.
- Fixed missing methods and exports (why were they removed to begin with, @Datseris? I'm thinking specifically of the `allcounts` etc methods that were generated previously)
- `entropy(::Probabilities)`, which was used in the doc tutorial, is not a valid syntax. I am happy with that, since I like to specify which entropy one wants to compute. However, we can also dispatch automatically to `entropy(Shannon(), p)`. Not sure what is the best. Here I just modified the examples in the tutorial to be explicit about using `Shannon`