### PR TITLE
Add functionality clarifying method to codify

### DIFF
--- a/src/outcome_spaces/ordinal_patterns.jl
+++ b/src/outcome_spaces/ordinal_patterns.jl
@@ -268,6 +268,10 @@ function codify(est::OrdinalOutcomeSpace{m}, x) where m
     return πs
 end
 
+function codify(est::OrdinalOutcomeSpace{m}, x::StateSpaceSet{1}) where m
+  throw(ArgumentError("Convert your univariate time series to a subtype of `AbstractVector` to codify with ordinal patterns! A `StateSpaceSet` input is assumed to be already embedded in D = m >= 2 dimensional space. "))
+end
+
 # Special treatment for counting-based
 function probabilities!(πs::Vector{Int}, est::OrdinalPatterns{m}, x::AbstractStateSpaceSet{m}) where {m}
     # This sorts πs in-place. For `OrdinalPatterns`, this returns actual integer counts.

--- a/test/outcome_spaces/implementations/permutation.jl
+++ b/test/outcome_spaces/implementations/permutation.jl
@@ -92,4 +92,5 @@ end
     # Codification of vector inputs (time series)
     x = rand(30)
     @test codify(S(), x) isa Vector{Int}
+    @test_throws ArgumentError codify(S(),StateSpaceSet(x))
 end


### PR DESCRIPTION
Error message clarification of `codify` discussed  here #358 