### PR TITLE
Move input check for `codify` with 1-dimensional state space sets and ordinal outcome spaces

### DIFF
--- a/src/outcome_spaces/ordinal_patterns.jl
+++ b/src/outcome_spaces/ordinal_patterns.jl
@@ -256,7 +256,10 @@ function codify(est::OrdinalOutcomeSpace{m}, x) where m
     if x isa AbstractVector
         dataset = embed(x, m, est.τ)
     elseif x isa AbstractStateSpaceSet && dimension(x) == 1
-        throw(ArgumentError("Convert your univariate time series to a subtype of `AbstractVector` to codify with ordinal patterns! A `StateSpaceSet` input is assumed to be already embedded in D = m >= 2 dimensional space."))
+        err = "Convert your univariate time series to a subtype of `AbstractVector` to " * 
+        "codify with ordinal patterns! A `StateSpaceSet` input is assumed to be " * 
+        "already  embedded in D = m >= 2 dimensional space."
+        throw(ArgumentError(err))
     else
         dataset = x
     end

--- a/src/outcome_spaces/ordinal_patterns.jl
+++ b/src/outcome_spaces/ordinal_patterns.jl
@@ -255,7 +255,7 @@ end
 function codify(est::OrdinalOutcomeSpace{m}, x) where m
     if x isa AbstractVector
         dataset = embed(x, m, est.τ)
-    elseif x isa AbstractStateSpaceSet{1}
+    elseif x isa AbstractStateSpaceSet && dimension(x) == 1
         throw(ArgumentError("Convert your univariate time series to a subtype of `AbstractVector` to codify with ordinal patterns! A `StateSpaceSet` input is assumed to be already embedded in D = m >= 2 dimensional space."))
     else
         dataset = x

--- a/src/outcome_spaces/ordinal_patterns.jl
+++ b/src/outcome_spaces/ordinal_patterns.jl
@@ -255,6 +255,8 @@ end
 function codify(est::OrdinalOutcomeSpace{m}, x) where m
     if x isa AbstractVector
         dataset = embed(x, m, est.τ)
+    elseif x isa AbstractStateSpaceSet{1}
+        throw(ArgumentError("Convert your univariate time series to a subtype of `AbstractVector` to codify with ordinal patterns! A `StateSpaceSet` input is assumed to be already embedded in D = m >= 2 dimensional space."))
     else
         dataset = x
     end
@@ -266,10 +268,6 @@ function codify(est::OrdinalOutcomeSpace{m}, x) where m
         πs[i] = encode(est.encoding, χ)
     end
     return πs
-end
-
-function codify(est::OrdinalOutcomeSpace{m}, x::StateSpaceSet{1}) where m
-  throw(ArgumentError("Convert your univariate time series to a subtype of `AbstractVector` to codify with ordinal patterns! A `StateSpaceSet` input is assumed to be already embedded in D = m >= 2 dimensional space. "))
 end
 
 # Special treatment for counting-based


### PR DESCRIPTION
Addresses https://github.com/JuliaDynamics/ComplexityMeasures.jl/pull/359#issuecomment-1880996987.