### PR TITLE
Add missing method with q first for deprecated `genentropy`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ComplexityMeasures"
 uuid = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/ComplexityMeasures.jl.git"
-version = "3.0.1"
+version = "3.0.2"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -83,15 +83,7 @@ end
 
 function genentropy(x::Array_or_SSSet, o::OutcomeSpace; q = 1.0, base = MathConstants.e)
     @warn """
-    `genentropy(x::Array_or_SSSet, est::ProbabilitiesEstimator; q, base)` is deprecated.
-    Use instead: `information(Renyi(q, base), est, x)`.
-    """
-    return information(Renyi(q, base), RelativeAmount(), o, x)
-end
-
-function genentropy(q::Real, x::Array_or_SSSet, o::OutcomeSpace; base = MathConstants.e)
-    @warn """
-    `genentropy(q::Real, x::Array_or_SSSet, est::ProbabilitiesEstimator; q, base)` is deprecated.
+    `genentropy(x::Array_or_SSSet, o::OutcomeSpace; q, base)` is deprecated.
     Use instead: `information(Renyi(q, base), est, x)`.
     """
     return information(Renyi(q, base), RelativeAmount(), o, x)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -89,6 +89,14 @@ function genentropy(x::Array_or_SSSet, o::OutcomeSpace; q = 1.0, base = MathCons
     return information(Renyi(q, base), RelativeAmount(), o, x)
 end
 
+function genentropy(q::Real, x::Array_or_SSSet, o::OutcomeSpace; base = MathConstants.e)
+    @warn """
+    `genentropy(q::Real, x::Array_or_SSSet, est::ProbabilitiesEstimator; q, base)` is deprecated.
+    Use instead: `information(Renyi(q, base), est, x)`.
+    """
+    return information(Renyi(q, base), RelativeAmount(), o, x)
+end
+
 @deprecate SymbolicPermutation OrdinalPatterns
 @deprecate SymbolicWeightedPermutation WeightedOrdinalPatterns
 @deprecate SymbolicAmplitudeAwarePermutation AmplitudeAwareOrdinalPatterns


### PR DESCRIPTION
See the syntax mentioned in https://github.com/JuliaDynamics/ComplexityMeasures.jl/issues/366 