### PR TITLE
Fix method ambiguity and add tests for Base array extensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ComplexityMeasures"
 uuid = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/ComplexityMeasures.jl.git"
-version = "3.0.2"
+version = "3.0.3"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/core/counts.jl
+++ b/src/core/counts.jl
@@ -87,10 +87,13 @@ function generate_outcomes(x::AbstractArray{T, N}) where {T, N}
 end
 
 # extend base Array interface:
-for f in (:length, :size, :eachindex, :eltype, :parent,
+for f in (:length, :size, :eltype, :parent,
     :lastindex, :firstindex, :vec, :getindex, :iterate)
     @eval Base.$(f)(c::Counts, args...) = $(f)(c.cts, args...)
 end
+# One-argument definitions to avoid type ambiguities with Base:
+Base.eachindex(c::Counts) = eachindex(c.cts)
+
 Base.IteratorSize(::Counts) = Base.HasLength()
 
 # We strictly deal with single inputs here. For multi-inputs, see CausalityTools.jl

--- a/src/core/probabilities.jl
+++ b/src/core/probabilities.jl
@@ -92,11 +92,13 @@ function Probabilities(x::AbstractVector, outcomes::AbstractVector, label; norme
 end
 
 # extend base Array interface:
-for f in (:length, :size, :eachindex, :eltype, :parent,
+for f in (:length, :size, :eltype, :parent,
     :lastindex, :firstindex, :vec, :getindex, :iterate)
-    @eval Base.$(f)(d::Probabilities{T, N}, args...) where {T, N} = $(f)(d.p, args...)
+    @eval Base.$(f)(d::Probabilities, args...)= $(f)(d.p, args...)
 end
 
+# One-argument definitions to avoid type ambiguities with Base:
+Base.eachindex(p::Probabilities) = eachindex(p.p)
 # Other useful methods:
 Base.sort(p::Probabilities) = sort(p.p)
 

--- a/test/counts/core.jl
+++ b/test/counts/core.jl
@@ -26,6 +26,22 @@ oz = (collect(1:2), collect(1:2), collect(1:3))
 @test Counts(y, (1:2 |> collect, ['a', 'b'])) isa Counts{T, 2} where {T}
 @test Counts(z, (1:2, ['a', 'b'], 7:9)) isa Counts{T, 3} where {T}
 
+# ----------------------------------------------------------------
+# Base extensions 
+# ----------------------------------------------------------------
+c = Counts(x, ox)
+# extend base Array interface:
+@test length(c) == length(c.cts)
+@test size(c) == size(c.cts)
+@test eachindex(c) == eachindex(c.cts)
+@test eltype(c) == eltype(c.cts)
+@test parent(c) == parent(c.cts)
+@test firstindex(c) == firstindex(c.cts)
+@test lastindex(c) == lastindex(c.cts)
+@test vec(c) == vec(c.cts)
+@test getindex(c, 2) == getindex(c.cts, 2)
+@test iterate(c) == iterate(c.cts)
+@test sort(c) == sort(c.cts)
 
 # ================================================================
 # Outcomes

--- a/test/deprecations.jl
+++ b/test/deprecations.jl
@@ -15,7 +15,7 @@ rng = Xoshiro(1234)
     msg = "`genentropy(probs::Probabilities; q, base)` deprecated.\nUse instead: `information(Renyi(q, base), probs)`.\n"
     @test_logs (:warn, msg) genentropy(Probabilities(rand(rng, 3)))
 
-    msg = "`genentropy(x::Array_or_SSSet, est::ProbabilitiesEstimator; q, base)` is deprecated.\nUse instead: `information(Renyi(q, base), est, x)`.\n"
+    msg = "`genentropy(x::Array_or_SSSet, o::OutcomeSpace; q, base)` is deprecated.\nUse instead: `information(Renyi(q, base), est, x)`.\n"
     @test_logs (:warn, msg) genentropy(x, ValueBinning(0.1))
 
     @test probabilities(x, 0.1) == probabilities(ValueBinning(0.1), x)

--- a/test/probabilities/probabilities.jl
+++ b/test/probabilities/probabilities.jl
@@ -11,6 +11,23 @@ outs = collect(1:10)
 @test Probabilities(rand(rng, 10), (outs,)) isa Probabilities
 @test Probabilities(rand(rng, 10), (outs,), (:x1, )) isa Probabilities
 
+# ----------------------------------------------------------------
+# Base extensions 
+# ----------------------------------------------------------------
+p =  Probabilities(rand(rng, 10), outs)
+# extend base Array interface:
+@test length(p) == length(p.p)
+@test size(p) == size(p.p)
+@test eachindex(p) == eachindex(p.p)
+@test eltype(p) == eltype(p.p)
+@test parent(p) == parent(p.p)
+@test firstindex(p) == firstindex(p.p)
+@test lastindex(p) == lastindex(p.p)
+@test vec(p) == vec(p.p)
+@test getindex(c, 2) == getindex(c.cts, 2)
+@test iterate(p) == iterate(p.p)
+@test sort(p) == sort(p.p)
+
 # The number of probabilities and outcomes must match.
 @test_throws ArgumentError Probabilities(rand(1:3, 10), (1:9,))
 


### PR DESCRIPTION
Closes #369.

Also fixes broken tests on `main` introduced by https://github.com/JuliaDynamics/ComplexityMeasures.jl/commit/1ebda7bf05aa2c7c1f4221a5ef59f38f500143b9, where tests where not updated in accordance with the new deprecation message.