### PR TITLE
Nicer default printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 Changelog is kept with respect to version 0.11 of Entropies.jl. From version v2.0 onwards, this package has been renamed to ComplexityMeasures.jl.
 
-## 3
+## 3.1
+
+- Pretty printing for `Encoding`s, `OutcomeSpace`s, `ProbabilitiesEstimator`s,
+    `InformationMeasure`s, `InformationMeasureEstimator`s and `ComplexityEstimator`s.
+
+## 3.0
 
 ComplexityMeasures.jl has undergone major overhaul of the internal design.
 Additionally, a large number of exported names have been renamed. Despite the major

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ComplexityMeasures"
 uuid = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/ComplexityMeasures.jl.git"
-version = "3.0.5"
+version = "3.1.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/ComplexityMeasures.jl
+++ b/src/ComplexityMeasures.jl
@@ -26,6 +26,7 @@ include("core/encodings.jl")
 include("core/complexity.jl")
 include("multiscale.jl")
 include("convenience.jl")
+include("core/pretty_printing.jl")
 
 # Library implementations (files include other files)
 include("encoding_implementations/encoding_implementations.jl")

--- a/src/complexity_measures/statistical_complexity.jl
+++ b/src/complexity_measures/statistical_complexity.jl
@@ -94,6 +94,13 @@ struct StatisticalComplexity{D,
     entr_val::Base.RefValue{T} where T
 end
 
+# ----------------------------------------------------------------
+# Pretty printing (see /core/pretty_printing.jl).
+# ----------------------------------------------------------------
+oneline_printing(::Type{<:StatisticalComplexity}) = false
+hidefields(::Type{<:StatisticalComplexity}) = [:entr_val]
+
+
 function StatisticalComplexity(; 
         dist::D = JSDivergence(), 
         hest::H = PlugIn(Renyi()), 

--- a/src/complexity_measures/statistical_complexity.jl
+++ b/src/complexity_measures/statistical_complexity.jl
@@ -97,9 +97,7 @@ end
 # ----------------------------------------------------------------
 # Pretty printing (see /core/pretty_printing.jl).
 # ----------------------------------------------------------------
-oneline_printing(::Type{<:StatisticalComplexity}) = false
 hidefields(::Type{<:StatisticalComplexity}) = [:entr_val]
-
 
 function StatisticalComplexity(; 
         dist::D = JSDivergence(), 

--- a/src/core/pretty_printing.jl
+++ b/src/core/pretty_printing.jl
@@ -149,9 +149,11 @@ function printcomponents(x; custom_fieldcolor = :default, compact = true)
     v = Vector{FANCY_PRINTABLE}(undef, 0)
     T = typeof(x)
     N = T.name.name
-    push!(v, PrintComponent("$N("; color = type_printcolor(T), bold = true))
+    push!(v, PrintComponent("$N"; color = type_printcolor(T), bold = true))
     if !compact
-        push!(v, PrintComponent("\n$tabSpace"; hidden=false))
+        push!(v, PrintComponent(" with fields\n$tabSpace"))
+    else
+        push!(v, PrintComponent("("; hidden=false))
     end
     shownames = [name for name in relevant_fieldnames(x) if !(name in hidefields(T))]
     
@@ -169,8 +171,9 @@ function printcomponents(x; custom_fieldcolor = :default, compact = true)
     if !compact
         push!(v, PrintComponent("\n"; hidden=false))
     end
-    push!(v, PrintComponent(")"; color = type_printcolor(T), bold = true))
-    
+    if compact
+        push!(v, PrintComponent(")"; color = type_printcolor(T), bold = true))
+    end
 
     # Don't convert to PrintComponents yet, because that will lead to a nested mess.
     # We convert inside the extension to `Base.show` instead (see below).
@@ -187,7 +190,7 @@ for S in our_abstract_types
         else
             compact = false
         end
-        p = PrintComponents(printcomponents(x, compact = compact))
+        p = PrintComponents(printcomponents(x; compact))
         show(io, p)
     end
     # For compact printing (inside vectors, tuples etc)

--- a/src/core/pretty_printing.jl
+++ b/src/core/pretty_printing.jl
@@ -1,0 +1,164 @@
+
+
+"""
+    relevant_fieldnames(x::T) → names::Vector{Symbol}
+
+Internal method that returns the relevant field names to be printed for type `T`.
+For example, for `Encodings`, the implementation is simply
+
+```julia
+relevant_fieldnames(e::Encoding) = fieldnames(typeof(e))
+```
+
+Individual types can override this method if special printing is desired.
+"""
+relevant_fieldnames(x) = fieldnames(typeof(x))
+
+"""
+    typecolor(x) → color::Symbol
+
+The color in which to print the type name for type `typeof(x)`.
+
+Can be used to distinguish different types, so that nested printing looks better (e.g.
+`Encoding`s inside `OutcomeSpace`s).
+"""
+typecolor(x) = :normal
+
+export PrintComponent
+"""
+    PrintComponent
+    PrintComponent(s; color::Union{Symbol,Int} = :normal,
+        bold::Bool = false, underline::Bool = false, blink::Bool = false,
+        hidden::Bool = false, reverse::Bool = false)
+
+Stores a string `s` and instructions for how it shall be printed. 
+    
+`PrintComponent`s are intended for use with `printstyled`.
+"""
+struct PrintComponent{S<:AbstractString}
+    s::S
+    color::Union{Symbol,Int}
+    bold::Bool
+    underline::Bool
+    blink::Bool
+    hidden::Bool
+    reverse::Bool
+
+    function PrintComponent(s::S; color::Union{Symbol,Int} = :normal,
+        bold::Bool = false, underline::Bool = false, blink::Bool = false,
+        hidden::Bool = false, reverse::Bool = false) where S
+        new{S}(s, color, bold, underline, blink, hidden, reverse) 
+    end
+end
+Base.show(io::IO, x::PrintComponent) = printstyled(io, x.s; 
+    color = x.color, bold = x.bold, underline = x.underline, blink = x.blink,
+    hidden = x.hidden, reverse = x.reverse)
+
+# Stores a vector of `PrintComponent` which give instructions on how to print 
+# an entire type (not just a field). The reason for having this type is so that 
+# we can print nested formatted types using `PrintComponents`
+struct EntireComponent
+    s::Vector{PrintComponent}
+end
+
+
+struct PrintComponents{T <: Union{PrintComponent, EntireComponent}}
+    x::Vector{T}
+end
+
+
+function Base.show(io::IO, x::PrintComponents) 
+    for component in x.x
+        show(component)
+    end
+end
+
+# Modify here if more of our types should be considered.
+our_types = [Encoding, OutcomeSpace]
+
+function single_print_component!(v, name, fieldval)
+    push!(v, PrintComponent("$name"; bold=true, color=:blue))
+    push!(v, PrintComponent(" = "; bold=true, color=:normal))
+    if any(typeof(fieldval) <: T for T in our_types)
+        push!(v, printcomponents(fieldval))
+    else
+        push!(v, PrintComponent("$fieldval"; bold=true, color=:normal))
+    end
+end
+
+
+# TODO: extras for certain types, e.g. {m} for OrdinalPatterns.
+export printcomponents
+function printcomponents(x)
+    v = []
+    T = typeof(x)
+    N = T.name.name
+    names = relevant_fieldnames(x)
+    push!(v, PrintComponent("$N("))
+    for (i, name) in enumerate(names)
+        single_print_component!(v, name, getfield(x, name))
+        if i < length(names)
+            push!(v, PrintComponent(", "; bold=true, color=:normal))
+        end
+    end
+    push!(v, PrintComponent(")"))
+    return v
+end
+
+for S in Symbol.(our_types)
+    @eval function Base.show(io::IO, x::$S)
+        show(io, printcomponents(x))
+    end
+end
+
+
+# for S in Symbol.(our_types)
+#     @eval function print_subcomponent(io::IO, x::$S)
+#         show(io, printcomponents(x))
+#         # T = typeof(x)
+#         # N = T.name.name
+#         # names = relevant_fieldnames(x)
+#         # print(io, "$N(")
+
+#         # for (i, name) in enumerate(names)
+#         #     printstyled(io, "$name"; bold=true, color=:blue)
+#         #     printstyled(io, " = "; bold=true, color=:normal)
+#         #     printstyled(io, "$(getfield(x, name))"; bold=true, color=:normal)
+#         #     if i < length(names)
+#         #         printstyled(io, ", "; bold=true, color=:normal)
+#         #     end
+#         # end
+#         # print(io, ")")
+#     end
+# end
+
+# # # 
+# our_types = [Encoding, OutcomeSpace]
+# for S in Symbol.(our_types)
+#     @eval function Base.show(io::IO, x::$S)
+#         T = typeof(x)
+#         N = T.name.name
+#         names = relevant_fieldnames(x)
+#         fieldvals = (getfield(x, name) for name in names)
+
+#         print(io, "$N(")
+#         for (i, name) in enumerate(names)
+#             printstyled(io, "$name"; bold=true, color=:blue)
+#             printstyled(io, " = "; bold=true, color=:normal)
+#             field = getfield(x, name)
+#             #@show typeof(field)
+
+#             # We pretty print our own types, but leave other types to default printing.
+#             if typeof(field) in our_types
+#                 show(printcomponents(field))
+#             else
+#                 printstyled(io, "$(getfield(x, name))"; bold=true, color=:normal)
+#             end
+
+#             if i < length(names)
+#                 printstyled(io, ", "; bold=true, color=:normal)
+#             end
+#         end
+#         print(io, ")")
+#     end
+# end

--- a/src/core/pretty_printing.jl
+++ b/src/core/pretty_printing.jl
@@ -85,17 +85,26 @@ function Base.show(io::IO, x::PrintComponents)
 end
 
 # Modify here if more of our abstract types should be considered.
-our_abstract_types = [Encoding, OutcomeSpace, ProbabilitiesEstimator, InformationMeasure]
+our_abstract_types = [Encoding, 
+    OutcomeSpace, 
+    ProbabilitiesEstimator, 
+    InformationMeasure,
+    DiscreteInfoEstimator,
+    DifferentialInfoEstimator,
+    ComplexityEstimator
+]
 
 type_printcolor(x::Type{<:Encoding}) = :red
 type_printcolor(x::Type{<:OutcomeSpace}) = :blue
 type_printcolor(x::Type{<:ProbabilitiesEstimator}) = :green
 type_printcolor(x::Type{<:InformationMeasure}) = :magenta
+type_printcolor(x::Type{<:ComplexityEstimator}) = :magenta
 
 type_field_printcolor(x::Type{<:Encoding}) = :red
 type_field_printcolor(x::Type{<:OutcomeSpace}) = :light_blue
 type_field_printcolor(x::Type{<:ProbabilitiesEstimator}) = :light_green
 type_field_printcolor(x::Type{<:InformationMeasure}) = :light_magenta
+type_field_printcolor(x::Type{<:ComplexityEstimator}) = :light_magenta
 
 function single_print_component!(v, name, fieldval, x; fieldcol = :grey)
     # Field names are colored as a weaker variant of the parent type color.

--- a/src/core/pretty_printing.jl
+++ b/src/core/pretty_printing.jl
@@ -140,9 +140,6 @@ function single_print_component!(v, name, fieldval, x; fieldcol = :grey)
     # Use standard formatting for the rest.
     push!(v, PrintComponent(" = "; bold=false, color = :default))
     if any(typeof(fieldval) <: T for T in our_abstract_types)
-        # If we want more aggressive coloring, switch to this:
-        #custom_fieldcolor = type_field_printcolor(typeof(fieldval))
-        #comps = printcomponents(fieldval; custom_fieldcolor)
         comps = printcomponents(fieldval)
         push!(v, EntireComponent(comps))
     else

--- a/src/encoding_implementations/combination_encoding.jl
+++ b/src/encoding_implementations/combination_encoding.jl
@@ -67,6 +67,12 @@ struct CombinationEncoding{N, L, C} <: Encoding
         new{N, L, C}(encodings, l, c)
     end
 end
+
+# ----------------------------------------------------------------
+# Pretty printing (see /core/pretty_printing.jl).
+# ----------------------------------------------------------------
+hidefields(::Type{<:CombinationEncoding}) = [:linear_indices, :cartesian_indices]
+
 CombinationEncoding(encodings) = CombinationEncoding(encodings...)
 function CombinationEncoding(encodings::Vararg{Encoding, N}) where N
     ranges = tuple([1:total_outcomes(e) for e in encodings]...)

--- a/src/encoding_implementations/gaussian_cdf.jl
+++ b/src/encoding_implementations/gaussian_cdf.jl
@@ -104,6 +104,11 @@ struct GaussianCDFEncoding{m, T, L <: LinearIndices, C <: CartesianIndices, R} <
     end
 end
 
+# ----------------------------------------------------------------
+# Pretty printing (see /core/pretty_printing.jl).
+# ----------------------------------------------------------------
+hidefields(::Type{<:GaussianCDFEncoding}) = [:linear_indices, :cartesian_indices, :binencoder]
+
 # Backwards compatibility (previously, only scalars were encodable)
 GaussianCDFEncoding(; kwargs...) = GaussianCDFEncoding{1}(; kwargs...)
 

--- a/src/encoding_implementations/ordinal_pattern.jl
+++ b/src/encoding_implementations/ordinal_pattern.jl
@@ -49,6 +49,8 @@ struct OrdinalPatternEncoding{M, F} <: Encoding
     perm::MVector{M, Int}
     lt::F
 end
+special_typeparameter_info(::Type{OrdinalPatternEncoding{m}}) where m = "{$m}"
+
 function OrdinalPatternEncoding{m}(lt::F = isless_rand) where {m,F}
     OrdinalPatternEncoding{m, F}(zero(MVector{m, Int}), lt)
 end

--- a/src/encoding_implementations/relative_first_difference_encoding.jl
+++ b/src/encoding_implementations/relative_first_difference_encoding.jl
@@ -62,6 +62,11 @@ Base.@kwdef struct RelativeFirstDifferenceEncoding{R} <: Encoding
     end
 end
 
+# ----------------------------------------------------------------
+# Pretty printing (see /core/pretty_printing.jl).
+# ----------------------------------------------------------------
+hidefields(::Type{<:RelativeFirstDifferenceEncoding}) = [:binencoder]
+
 function RelativeFirstDifferenceEncoding(minval::Real, maxval::Real; n = 2)
     binencoder = RectangularBinEncoding(FixedRectangularBinning(0, 1, n + 1))
     return RelativeFirstDifferenceEncoding(n, minval, maxval, binencoder)

--- a/src/encoding_implementations/relative_mean_encoding.jl
+++ b/src/encoding_implementations/relative_mean_encoding.jl
@@ -48,6 +48,11 @@ struct RelativeMeanEncoding{R} <: Encoding
     end
 end
 
+# ----------------------------------------------------------------
+# Pretty printing (see /core/pretty_printing.jl).
+# ----------------------------------------------------------------
+hidefields(::Type{<:RelativeMeanEncoding}) = [:binencoder]
+
 function RelativeMeanEncoding(minval::Real, maxval::Real; n = 2)
     binencoder = RectangularBinEncoding(FixedRectangularBinning(0, 1, n + 1))
     return RelativeMeanEncoding(n, minval, maxval, binencoder)

--- a/src/outcome_spaces/ordinal_patterns.jl
+++ b/src/outcome_spaces/ordinal_patterns.jl
@@ -13,6 +13,8 @@ Subtypes must implement fields:
     permutation patterns from embedding vectors.
 """
 abstract type OrdinalOutcomeSpace{m} <: CountBasedOutcomeSpace end
+special_typeparameter_info(::Type{<:OrdinalOutcomeSpace{m}}) where m = "{$m}"
+
 # we use the supertype above but not ordinal pattern outcome spaces
 # are actually counti based, see the explicit `is_counting_based` extensions
 

--- a/test/complexity/measures/statistical_complexity.jl
+++ b/test/complexity/measures/statistical_complexity.jl
@@ -112,3 +112,18 @@ end
     @test compl == 0.0
 end
 
+
+# ----------------------------------------------------------------
+# Pretty printing
+# ----------------------------------------------------------------
+r = repr(StatisticalComplexity())
+
+fns = fieldnames(StatisticalComplexity)
+hidden_fields = ComplexityMeasures.hidefields(StatisticalComplexity)
+displayed_fields = setdiff(fns, hidden_fields)
+for fn in displayed_fields
+    @test occursin("$fn = ", r)
+end
+for fn in hidden_fields
+    @test !occursin("entr_val = ", r)
+end

--- a/test/encodings/encodings/combination_encoding.jl
+++ b/test/encodings/encodings/combination_encoding.jl
@@ -43,3 +43,16 @@ s_c = encode(comboencoding, x)
 
 @test decode(comboencoding, s_c)[1][1] ≈ 0.0 # left bin edge of first subinterval is zero
 @test decode(comboencoding, s_c)[2] == [2, 3, 1] # idxs that would sort `x`
+
+# ----------------------------------------------------------------
+# Pretty printing
+# ----------------------------------------------------------------
+encodings = (
+    RelativeFirstDifferenceEncoding(0, 1; n = 2),
+    RelativeMeanEncoding(0, 1; n = 5),
+    OrdinalPatternEncoding(3) # x is a three-element vector
+    )
+c = CombinationEncoding(encodings)
+@test occursin("encodings = ", repr(c))
+@test !occursin("linear_indices = ", repr(c))
+@test !occursin("cartesian_indices = ", repr(c))

--- a/test/encodings/encodings/gaussian_cdf_encoding.jl
+++ b/test/encodings/encodings/gaussian_cdf_encoding.jl
@@ -64,3 +64,18 @@ s = encode(encoding, y)
 @test decode(encoding, s) isa AbstractVector{<:SVector}
 
 @test_throws ArgumentError encode(GaussianCDFEncoding{m-1}(; c = 3, μ, σ), y)
+
+# ----------------------------------------------------------------
+# Pretty printing
+# ----------------------------------------------------------------
+T = GaussianCDFEncoding
+r = repr(T(μ = 0.5, σ = 0.1))
+fns = fieldnames(T)
+hidden_fields = ComplexityMeasures.hidefields(T)
+displayed_fields = setdiff(fns, hidden_fields)
+for fn in displayed_fields
+    @test occursin("$fn = ", r)
+end
+for fn in hidden_fields
+    @test !occursin("$fn = ", r)
+end

--- a/test/encodings/encodings/ordinal_pattern_encoding.jl
+++ b/test/encodings/encodings/ordinal_pattern_encoding.jl
@@ -57,3 +57,13 @@ end
     y = [1, 2, 1, 2] # only two patterns, none missing
     @test missing_outcomes(OrdinalPatterns(; m, τ), x) == 0
 end
+
+@testset "Pretty printing" begin 
+    o = OrdinalPatterns{3}()
+    @test occursin("OrdinalPatterns{3}", repr(o))
+    @test occursin("encoding = OrdinalPatternEncoding(perm = [0, 0, 0], lt = isless_rand), τ = 1", repr(o))
+
+    os = [o, o, o]
+    s = "[OrdinalPatterns{3}(encoding = OrdinalPatternEncoding(perm = [0, 0, 0], lt = isless_rand), τ = 1), OrdinalPatterns{3}(encoding = OrdinalPatternEncoding(perm = [0, 0, 0], lt = isless_rand), τ = 1), OrdinalPatterns{3}(encoding = OrdinalPatternEncoding(perm = [0, 0, 0], lt = isless_rand), τ = 1)]"
+    @test occursin(s, repr(os))
+end

--- a/test/pretty_printing.jl
+++ b/test/pretty_printing.jl
@@ -1,0 +1,34 @@
+using Test, ComplexityMeasures
+
+# ----------------------------------------------------------------
+# Types that doesn't require any special handling
+# 
+# Printing for types that require specialized printing is 
+# tested in their respective source files.
+# ----------------------------------------------------------------
+
+# Example 1: only one field (so compact representation)
+T = PlugIn
+r = repr(T())
+fns = fieldnames(T)
+hidden_fields = ComplexityMeasures.hidefields(T)
+displayed_fields = setdiff(fns, hidden_fields)
+for fn in displayed_fields
+    @test occursin("$fn = ", r)
+end
+for fn in hidden_fields
+    @test !occursin("$fn = ", r)
+end
+
+# Example 2: more than one field (no expanded representation)
+T = Renyi
+r = repr(T())
+fns = fieldnames(T)
+hidden_fields = ComplexityMeasures.hidefields(T)
+displayed_fields = setdiff(fns, hidden_fields)
+for fn in displayed_fields
+    @test occursin("$fn = ", r)
+end
+for fn in hidden_fields
+    @test !occursin("$fn = ", r)
+end

--- a/test/pretty_printing.jl
+++ b/test/pretty_printing.jl
@@ -32,3 +32,23 @@ end
 for fn in hidden_fields
     @test !occursin("$fn = ", r)
 end
+
+# A dummy information measure that contains all relevant types we want to test for.
+# This is just to ensure complete test coverage for pretty printing in the case 
+# of nested types.
+struct DummyPrint <: InformationMeasure
+    a
+    b
+    c
+    d
+    e
+    f
+end
+
+m = DummyPrint(PlugIn(), Kraskov(), RelativeMeanEncoding(0, 1), OrdinalPatterns{3}(), 
+    RelativeAmount(), MissingDispersionPatterns())
+dummyestimator = PlugIn(m)
+@test occursin("definition = ", repr(dummyestimator))
+
+
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ testfile(file, testname=defaultname(file)) = @testset "$testname" begin; include
     # Core
     testfile("counts/counts.jl")
     testfile("probabilities/probabilities.jl")
+    testfile("pretty_printing.jl")
 
     # # Outcome spaces
     testfile("outcome_spaces/outcome_spaces.jl")


### PR DESCRIPTION
Fixes #286.

Introduces:
- `core/pretty_printing.jl`. Contains generic pretty-printing code for relevant types in our package. Defines
    - The vector `our_abstract_types`, which lists the types for which we want to pretty-print.
    - Functions that can be overridden if special printing for individual types are needed. For example:
        - `hidefields` can be overridden to not display certain internal fields. Used e.g. for `RelativeMeanEncoding` to hide the `binencoder` field.
        - `special_typeparameter_info` can be overridden to display certain extra type information. By default, all type annotations are stripped away while pretty-printing. However, for `OrdinalPatterns` we want it to be printed as `OrdinalPatterns{3}(...)` and not `OrdinalPatterns(...)`. Overriding this method takes care of that.

## Formatting 
- Non-`ComplexityMeasures` types are printed with default typeface, font and color.
- `ComplexityMeasures` type names are printed with custom colors and font weight. Parentheses are color-matched to the names, so it is easier to see which fields belong to what type. The `type_printcolor` and `type_field_printcolor` functions determine which color is used for printing (default to the color `:default`). 
- In #286 we discussed that we could show the type for some fields and the actual values for other fields. Here, I opted for always showing the values. Pretty printing is always done in a nested manner. However, we can customize this for particular types if needed.I think it looks pretty decent as is, so that can be dealt with in separate issues if needed.

## Approach 

To ensure pretty printing is defined for all our types, we loop over `our_abstract_types`, and use `@eval` to override two `Base` methods:
- For stand-alone printing, we override `Base.show(io::IO, ::MIME"text/plain", x)`. The behavior is
   - If the type has only one field to be displayed, it is displayed in compact (one-line) form (screenshot example 1)
   - If the type has two or more fields, then it is displayed over multiple lines (screenshot example 2)
- For compact printing, e.g. inside vectors, we override `Base.show(io::IO, x)`. This will always display the one-line version  (screenshot example 3)

<img width="971" alt="Skjermbilde 2024-01-13 kl  12 56 52" src="https://github.com/JuliaDynamics/ComplexityMeasures.jl/assets/5237566/4fa0e511-cd35-4fa1-85e1-a723a45fc3ea">
