### PR TITLE
Better docstrings for probs and counts

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ComplexityMeasures"
 uuid = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/ComplexityMeasures.jl.git"
-version = "3.1.1"
+version = "3.1.2"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/core/counts.jl
+++ b/src/core/counts.jl
@@ -25,15 +25,15 @@ export is_counting_based
 ###########################################################################################
 """
     Counts <: Array{<:Integer, N}
-    Counts(counts [, outcomes [, outnames]]) → c
+    Counts(counts [, outcomes [, dimlabels]]) → c
 
 `Counts` stores an `N`-dimensional array of integer `counts` corresponding to a set of
 `outcomes`. This is typically called a "frequency table" or
 ["contingency table"](https://en.wikipedia.org/wiki/Contingency_table).
 
-If `c isa Counts`, then `c.outcomes[i]` is the outcomes along the `i`-th dimension,
-each being an abstract vector whose order is the same one corresponding to `c`,
-and `c.dimlabels[i]` is the label of the `i`-th dimension.
+If `c isa Counts`, then `c.outcomes[i]` is an abstract vector containing the outcomes
+along the `i`-th dimension, where `c[i][j]` is the count corresponding to the outcome
+`c.outcomes[i][j]`, and `c.dimlabels[i]` is the label of the `i`-th dimension.
 Both labels and outcomes are assigned automatically if not given.
 `c` itself can be manipulated and iterated over like its stored array.
 """

--- a/src/core/probabilities.jl
+++ b/src/core/probabilities.jl
@@ -17,7 +17,6 @@ export missing_outcomes
 the array sums to 1 (normalized probability mass). In most cases the array is a standard
 vector. `p` itself can be manipulated and iterated over, just like its stored array.
 
-## Outcomes
 
 The probabilities correspond to `outcomes` that describe the axes of the array. 
 If `p isa Probabilities`, then `p.outcomes[i]` is an an abstract vector containing 

--- a/src/core/probabilities.jl
+++ b/src/core/probabilities.jl
@@ -17,9 +17,9 @@ export missing_outcomes
 the array sums to 1 (normalized probability mass). In most cases the array is a standard
 vector. `p` itself can be manipulated and iterated over, just like its stored array.
 
-## Outcomes and labels
+## Outcomes
 
-The probabilities correspond to outcomes that describe the axes of the array. 
+The probabilities correspond to `outcomes` that describe the axes of the array. 
 If `p isa Probabilities`, then `p.outcomes[i]` is an an abstract vector containing 
 the outcomes along the `i`-th dimension. The outcomes have the same ordering as the 
 probabilities, so that `p[i][j]` is the probability for outcome `p.outcomes[i][j]`. 

--- a/src/core/probabilities.jl
+++ b/src/core/probabilities.jl
@@ -32,9 +32,7 @@ then the labels and outcomes are inherited from the counts.
 ## Examples 
 
 ```julia
-julia> probs = [0.2, 0.2, 0.2, 0.2]; 
-
-julia> Probabilities(probs) # will be normalized to sum to 1
+julia> probs = [0.2, 0.2, 0.2, 0.2]; Probabilities(probs) # will be normalized to sum to 1
  Probabilities{Float64,1} over 4 outcomes
  Outcome(1)  0.25
  Outcome(2)  0.25
@@ -43,9 +41,7 @@ julia> Probabilities(probs) # will be normalized to sum to 1
 ```
 
 ```julia
-julia> c = Counts([12, 16, 12], ["out1", "out2", "out3"]);
-
-julia> Probabilities(c)
+julia> c = Counts([12, 16, 12], ["out1", "out2", "out3"]); Probabilities(c)
  Probabilities{Float64,1} over 3 outcomes
  "out1"  0.3
  "out2"  0.4

--- a/src/core/probabilities.jl
+++ b/src/core/probabilities.jl
@@ -10,8 +10,8 @@ export missing_outcomes
 ###########################################################################################
 """
     Probabilities <: Array{<:AbstractFloat, N}
-    Probabilities(probs::Array, [, outcomes [, dimlabels]]) → p
-    Probabilities(counts::Counts, [, outcomes [, dimlabels]]) → p
+    Probabilities(probs::Array [, outcomes [, dimlabels]]) → p
+    Probabilities(counts::Counts [, outcomes [, dimlabels]]) → p
 
 `Probabilities` stores an `N`-dimensional array of probabilities, while ensuring that
 the array sums to 1 (normalized probability mass). In most cases the array is a standard

--- a/src/core/probabilities.jl
+++ b/src/core/probabilities.jl
@@ -10,17 +10,47 @@ export missing_outcomes
 ###########################################################################################
 """
     Probabilities <: Array{<:AbstractFloat, N}
-    Probabilities(counts/probs [, outcomes [, outnames]]) → p
+    Probabilities(probs::Array, [, outcomes [, dimlabels]]) → p
+    Probabilities(counts::Counts, [, outcomes [, dimlabels]]) → p
 
 `Probabilities` stores an `N`-dimensional array of probabilities, while ensuring that
-the array sums to 1 (normalized probability mass). The probabilities correspond to outcomes
-that describe the axes of the array. In most cases the array is a standard vector.
+the array sums to 1 (normalized probability mass). In most cases the array is a standard
+vector. `p` itself can be manipulated and iterated over, just like its stored array.
 
-If `p isa Probabilities`, then `p.outcomes[i]` is the outcomes along the `i`-th dimension,
-each being an abstract vector whose order is the same one corresponding to `p`,
-and `p.dimlabels[i]` is the label of the `i`-th dimension.
-Both labels and outcomes are assigned automatically if not given.
-`p` itself can be manipulated and iterated over like its stored array.
+## Outcomes and labels
+
+The probabilities correspond to outcomes that describe the axes of the array. 
+If `p isa Probabilities`, then `p.outcomes[i]` is an an abstract vector containing 
+the outcomes along the `i`-th dimension. The outcomes have the same ordering as the 
+probabilities, so that `p[i][j]` is the probability for outcome `p.outcomes[i][j]`. 
+The dimensions of the array are named, and can be accessed by `p.dimlabels`, where 
+`p.dimlabels[i]` is the label of the `i`-th dimension. Both `outcomes` and `dimlabels`
+are assigned automatically if not given. If the input is a
+set of [`Counts`](@ref), and `outcomes` and `dimlabels` are not given, 
+then the labels and outcomes are inherited from the counts.
+
+## Examples 
+
+```julia
+julia> probs = [0.2, 0.2, 0.2, 0.2]; 
+
+julia> Probabilities(probs) # will be normalized to sum to 1
+ Probabilities{Float64,1} over 4 outcomes
+ Outcome(1)  0.25
+ Outcome(2)  0.25
+ Outcome(3)  0.25
+ Outcome(4)  0.25
+```
+
+```julia
+julia> c = Counts([12, 16, 12], ["out1", "out2", "out3"]);
+
+julia> Probabilities(c)
+ Probabilities{Float64,1} over 3 outcomes
+ "out1"  0.3
+ "out2"  0.4
+ "out3"  0.3
+```
 """
 struct Probabilities{T, N, S} <: AbstractArray{T, N}
     # The probabilities table.


### PR DESCRIPTION
Fixes the remainder of #370.

- There was no mention of `Counts` at all in the `Probabilities` doctoring, so the `probs_or_counts` argument in the docstring wasn't really making much sense. Therefore, I split the constructor signature up into two lines, and explicitly reference `Counts`.
- Clarified that when inputting `Counts` without specifying `outcomes`, then the outcomes are inherited from `Counts`.
- Slight rewording and a few extra words to make it explicit what "probabilities correspond to outcomes that describe axes" mean.  
- Added a few short examples of constructing a `Probabilities` (show, don't tell). This point can be omitted, but I find it useful.