### PR TITLE
Simplify MDP and missing outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Changelog is kept with respect to version 0.11 of Entropies.jl. From version v2.0 onwards, this package has been renamed to ComplexityMeasures.jl.
 
+## 3.2
+
+- `missing_outcomes` only works with count-based outcome spaces, which is what it should be doing based on its conceptual definition. Previous signature has been deprecated.
+- New function `missing_probabilities` that works with probability estimators and does the same as `missing_outcomes`.
+
 ## 3.1
 
 - Pretty printing for `Encoding`s, `OutcomeSpace`s, `ProbabilitiesEstimator`s,
@@ -12,7 +17,7 @@ Changelog is kept with respect to version 0.11 of Entropies.jl. From version v2.
 ComplexityMeasures.jl has undergone major overhaul of the internal design.
 Additionally, a large number of exported names have been renamed. Despite the major
 version change, this release does not contain strictly breaking changes. Instead,
-deprecations have been put in place everywhere. 
+deprecations have been put in place everywhere.
 
 The main renames and re-thinking of the library design are:
 
@@ -20,7 +25,7 @@ The main renames and re-thinking of the library design are:
     been renamed to  `information`. We consider as "information measures" anything that is
     a functional of probability mass/density functions, and these are estimated using
     `DiscreteInfoEstimator`s or `DifferentialInfoEstimator`s.
--  We realized that types like `ValueBinning`, `OrdinalPatterns` and `Dispersion` don't 
+-  We realized that types like `ValueBinning`, `OrdinalPatterns` and `Dispersion` don't
     actually represent probabilities estimators, but *outcome spaces*. To convery this
     fact, from 3.0, these types are subtypes of `OutcomeSpace`.
 - Subtypes of `ProbabilitiesEstimator`s now represent distinct ways of estimating
@@ -40,7 +45,7 @@ concepts/changes.
     entries for possible outcomes that were not present in the data.
 - New _extropy_ definitions that count as information measures (and thus can be given to
     `information`): `ShannonExtropy`, `RenyiExtropy`, `TsallisExtropy`.
-- `StatisticalComplexity` is now compatible with any normalizable `InformationMeasure` 
+- `StatisticalComplexity` is now compatible with any normalizable `InformationMeasure`
     (previously `EntropyDefinition`).
 - `StatisticalComplexity` can now estimate probabilities using any combination of
     `ProbabilitiesEstimator` and `OutcomeSpace`.
@@ -69,7 +74,7 @@ concepts/changes.
     encoding is deprecated. It is given as a type parameter now, e.g.,
     `OrdinalPatterns{m}(...)` instead of `OrdinalPatterns(m = ..., ...)`.
 
-### Bug fixes 
+### Bug fixes
 
 - `outcome_space` for `Dispersion` now correctly returns the all possible **sorted**
     outcomes (as promised by the `outcome_space` docstring).

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ComplexityMeasures"
 uuid = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/ComplexityMeasures.jl.git"
-version = "3.1.2"
+version = "3.2.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/docs/src/probabilities.md
+++ b/docs/src/probabilities.md
@@ -101,6 +101,7 @@ probabilities
 probabilities_and_outcomes
 allprobabilities_and_outcomes
 probabilities!
+missing_probabilities
 ```
 
 ## Counts

--- a/src/complexity_measures/missing_dispersion.jl
+++ b/src/complexity_measures/missing_dispersion.jl
@@ -6,7 +6,7 @@ export MissingDispersionPatterns
 
 """
     MissingDispersionPatterns <: ComplexityEstimator
-    MissingDispersionPatterns(est = Dispersion())
+    MissingDispersionPatterns(est = Dispersion()) → mdp
 
 An estimator for the number of missing dispersion patterns (``N_{MDP}``), a complexity
 measure which can be used to detect nonlinearity in time series [Zhou2023](@cite).
@@ -16,21 +16,9 @@ uses [`missing_outcomes`](@ref).
 
 ## Description
 
-If used with [`complexity`](@ref), ``N_{MDP}`` is computed by first symbolising each
-`xᵢ ∈ x`, then embedding the resulting symbol sequence using the dispersion pattern
-estimator `est`, and computing the quantity
-
-```math
-N_{MDP} = L - N_{ODP},
-```
-
-where `L = total_outcomes(est)` (i.e. the total number of possible dispersion patterns),
-and ``N_{ODP}`` is defined as the number of *occurring* dispersion patterns.
-
-If used with [`complexity_normalized`](@ref), then ``N_{MDP}^N = (L - N_{ODP})/L`` is
-computed. The authors recommend that
-`total_outcomes(est.symbolization)^est.m << length(x) - est.m*est.τ + 1` to avoid
-undersampling.
+When used with [`complexity`](@ref), `complexity(mdp)` is syntactically equivalent
+with just [`missing_outcomes`](@ref)`(est)`. When used with [`complexity_normalized`](@ref),
+we further divide `missing_outcomes(est)/total_outcomes(est)`.
 
 !!! note "Encoding"
     [`Dispersion`](@ref)'s linear mapping from CDFs to integers is based on equidistant
@@ -40,10 +28,10 @@ undersampling.
 ## Usage
 
 In [Zhou2023](@citet), [`MissingDispersionPatterns`](@ref) is used to detect nonlinearity
-in time series by comparing the ``N_{MDP}`` for a time series `x` to ``N_{MDP}`` values for
-an ensemble of surrogates of `x`. If ``N_{MDP} > q_{MDP}^{WIAAFT}``, where
-``q_{MDP}^{WIAAFT}`` is some `q`-th quantile of the surrogate ensemble, then it is
-taken as evidence for nonlinearity.
+in time series by comparing the MDP for a time series `x` to values for
+an ensemble of surrogates of `x`, as per the standard analysis of TimeseriesSurrogates.jl.
+If the MDP value of ``x`` is significantly larger than some high quantile of the surrogate
+distribution, then it is taken as evidence for nonlinearity.
 
 See also: [`Dispersion`](@ref), [`ReverseDispersion`](@ref), [`total_outcomes`](@ref).
 """
@@ -51,10 +39,10 @@ Base.@kwdef struct MissingDispersionPatterns{D} <: ComplexityEstimator
     est::D = Dispersion()
 end
 
-function complexity(c::MissingDispersionPatterns, x::AbstractVector{T}) where T
+function complexity(c::MissingDispersionPatterns, x)
     return missing_outcomes(c.est, x)
 end
 
-function complexity_normalized(c::MissingDispersionPatterns, x::AbstractVector{T}) where T
+function complexity_normalized(c::MissingDispersionPatterns, x)
     return missing_outcomes(c.est, x) / total_outcomes(c.est, x)
 end

--- a/src/complexity_measures/missing_dispersion.jl
+++ b/src/complexity_measures/missing_dispersion.jl
@@ -28,7 +28,8 @@ the normalization is simply `missing_outcomes(o)/total_outcomes(o)`.
 
 In [Zhou2023](@citet), [`MissingDispersionPatterns`](@ref) is used to detect nonlinearity
 in time series by comparing the MDP for a time series `x` to values for
-an ensemble of surrogates of `x`, as per the standard analysis of TimeseriesSurrogates.jl.
+an ensemble of surrogates of `x`, as per the standard analysis of
+[TimeseriesSurrogates.jl](https://github.com/JuliaDynamics/TimeseriesSurrogates.jl)
 If the MDP value of ``x`` is significantly larger than some high quantile of the surrogate
 distribution, then it is taken as evidence for nonlinearity.
 

--- a/src/complexity_measures/missing_dispersion.jl
+++ b/src/complexity_measures/missing_dispersion.jl
@@ -6,19 +6,18 @@ export MissingDispersionPatterns
 
 """
     MissingDispersionPatterns <: ComplexityEstimator
-    MissingDispersionPatterns(est = Dispersion()) → mdp
+    MissingDispersionPatterns(o = Dispersion()) → mdp
 
 An estimator for the number of missing dispersion patterns (MDP), a complexity
 measure which can be used to detect nonlinearity in time series [Zhou2023](@cite).
 
-Used with [`complexity`](@ref) or [`complexity_normalized`](@ref), whose implementation
-uses [`missing_outcomes`](@ref).
+Used with [`complexity`](@ref) or [`complexity_normalized`](@ref).
 
 ## Description
 
 When used with [`complexity`](@ref), `complexity(mdp)` is syntactically equivalent
-with just [`missing_outcomes`](@ref)`(est)`. When used with [`complexity_normalized`](@ref),
-we further divide `missing_outcomes(est)/total_outcomes(est)`.
+with just [`missing_outcomes`](@ref)`(o)`. When used with [`complexity_normalized`](@ref),
+the normalization is simply `missing_outcomes(o)/total_outcomes(o)`.
 
 !!! note "Encoding"
     [`Dispersion`](@ref)'s linear mapping from CDFs to integers is based on equidistant

--- a/src/complexity_measures/missing_dispersion.jl
+++ b/src/complexity_measures/missing_dispersion.jl
@@ -8,7 +8,7 @@ export MissingDispersionPatterns
     MissingDispersionPatterns <: ComplexityEstimator
     MissingDispersionPatterns(est = Dispersion()) → mdp
 
-An estimator for the number of missing dispersion patterns (``N_{MDP}``), a complexity
+An estimator for the number of missing dispersion patterns (MDP), a complexity
 measure which can be used to detect nonlinearity in time series [Zhou2023](@cite).
 
 Used with [`complexity`](@ref) or [`complexity_normalized`](@ref), whose implementation

--- a/src/core/probabilities.jl
+++ b/src/core/probabilities.jl
@@ -1,9 +1,8 @@
-
 export ProbabilitiesEstimator, Probabilities
 export probabilities, probabilities!
 export probabilities_and_outcomes
 export allprobabilities_and_outcomes
-export missing_outcomes
+export missing_outcomes, missing_probabilities
 
 ###########################################################################################
 # Types
@@ -384,7 +383,6 @@ function missing_outcomes(o::OutcomeSpace, x)
     O = count(!iszero, cts)
     return L - O
 end
-
 
 """
     missing_probabilities([est::ProbabilitiesEstimator], o::OutcomeSpace, x)

--- a/src/core/probabilities.jl
+++ b/src/core/probabilities.jl
@@ -370,31 +370,32 @@ function allprobabilities(est::ProbabilitiesEstimator, o::OutcomeSpace, x)
 end
 
 """
-    missing_outcomes(o::OutcomeSpace, x; all = false) → n_missing::Int
+    missing_outcomes(o::OutcomeSpace, x; all = false) → n::Int
 
-Count the number of missing (i.e., zero-probability) outcomes
-specified by `o`, given input data `x`, using [`RelativeAmount`](@ref)
-probabilities estimation.
-
-If `all == true`, then [`allprobabilities`](@ref) is used to compute the probabilities.
-If `all == false`, then [`probabilities`](@ref) is used to compute the probabilities.
-
-    missing_outcomes(est::ProbabilitiesEstimator, o::OutcomeSpace, x) → n_missing::Int
-
-Like above, but specifying a custom [`ProbabilitiesEstimator`](@ref) too.
+Count the number of missing outcomes `n` (i.e., not occuring in the data)
+specified by `o`, given input data `x`. This function only works for count-based
+outcome spaces, use [`missing_probabilities`](@ref) otherwise.
 
 See also: [`MissingDispersionPatterns`](@ref).
 """
-missing_outcomes(o::OutcomeSpace, x; kw...) = missing_outcomes(RelativeAmount(), o, x; kw...)
+function missing_outcomes(o::OutcomeSpace, x)
+    cts = counts(o, x)
+    L = total_outcomes(o, x)
+    O = count(!iszero, cts)
+    return L - O
+end
 
-function missing_outcomes(est::ProbabilitiesEstimator, o::OutcomeSpace, x; all::Bool = false)
-    if all
-        probs = allprobabilities(est, o, x)
-        L = length(probs)
-    else
-        probs = probabilities(est, o, x)
-        L = total_outcomes(o, x)
-    end
+
+"""
+    missing_probabilities([est::ProbabilitiesEstimator], o::OutcomeSpace, x)
+
+Same as [`missing_outcomes`](@ref), but defines a "missing outcome" as an outcome
+having 0 probability according to `est`.
+"""
+missing_probabilities(o::OutcomeSpace, x) = missing_probabilities(RelativeAmount(), o, x)
+function missing_probabilities(est::ProbabilitiesEstimator, o::OutcomeSpace, x)
+    probs = probabilities(est, o, x)
+    L = total_outcomes(o, x)
     O = count(!iszero, probs)
     return L - O
 end

--- a/src/core/probabilities.jl
+++ b/src/core/probabilities.jl
@@ -18,17 +18,17 @@ the array sums to 1 (normalized probability mass). In most cases the array is a 
 vector. `p` itself can be manipulated and iterated over, just like its stored array.
 
 
-The probabilities correspond to `outcomes` that describe the axes of the array. 
-If `p isa Probabilities`, then `p.outcomes[i]` is an an abstract vector containing 
-the outcomes along the `i`-th dimension. The outcomes have the same ordering as the 
-probabilities, so that `p[i][j]` is the probability for outcome `p.outcomes[i][j]`. 
-The dimensions of the array are named, and can be accessed by `p.dimlabels`, where 
+The probabilities correspond to `outcomes` that describe the axes of the array.
+If `p isa Probabilities`, then `p.outcomes[i]` is an an abstract vector containing
+the outcomes along the `i`-th dimension. The outcomes have the same ordering as the
+probabilities, so that `p[i][j]` is the probability for outcome `p.outcomes[i][j]`.
+The dimensions of the array are named, and can be accessed by `p.dimlabels`, where
 `p.dimlabels[i]` is the label of the `i`-th dimension. Both `outcomes` and `dimlabels`
 are assigned automatically if not given. If the input is a
-set of [`Counts`](@ref), and `outcomes` and `dimlabels` are not given, 
+set of [`Counts`](@ref), and `outcomes` and `dimlabels` are not given,
 then the labels and outcomes are inherited from the counts.
 
-## Examples 
+## Examples
 
 ```julia
 julia> probs = [0.2, 0.2, 0.2, 0.2]; Probabilities(probs) # will be normalized to sum to 1
@@ -370,16 +370,14 @@ function allprobabilities(est::ProbabilitiesEstimator, o::OutcomeSpace, x)
 end
 
 """
-    missing_outcomes(o::OutcomeSpace, x; all = true) → n_missing::Int
+    missing_outcomes(o::OutcomeSpace, x; all = false) → n_missing::Int
 
 Count the number of missing (i.e., zero-probability) outcomes
 specified by `o`, given input data `x`, using [`RelativeAmount`](@ref)
 probabilities estimation.
 
-If `all == true`, then [`allprobabilities_and_outcomes`](@ref) is used to compute the probabilities.
+If `all == true`, then [`allprobabilities`](@ref) is used to compute the probabilities.
 If `all == false`, then [`probabilities`](@ref) is used to compute the probabilities.
-
-This is syntactically equivalent to `missing_outcomes(RelativeAmount(o), x)`.
 
     missing_outcomes(est::ProbabilitiesEstimator, o::OutcomeSpace, x) → n_missing::Int
 
@@ -387,19 +385,9 @@ Like above, but specifying a custom [`ProbabilitiesEstimator`](@ref) too.
 
 See also: [`MissingDispersionPatterns`](@ref).
 """
-function missing_outcomes(o::OutcomeSpace, x; all::Bool = true)
-    if all
-        probs = allprobabilities(o, x)
-        L = length(probs)
-    else
-        probs = probabilities(o, x)
-        L = total_outcomes(o, x)
-    end
-    O = count(!iszero, probs)
-    return L - O
-end
+missing_outcomes(o::OutcomeSpace, x; kw...) = missing_outcomes(RelativeAmount(), o, x; kw...)
 
-function missing_outcomes(est::ProbabilitiesEstimator, o::OutcomeSpace, x; all::Bool = true)
+function missing_outcomes(est::ProbabilitiesEstimator, o::OutcomeSpace, x; all::Bool = false)
     if all
         probs = allprobabilities(est, o, x)
         L = length(probs)

--- a/src/core/probabilities.jl
+++ b/src/core/probabilities.jl
@@ -377,7 +377,12 @@ outcome spaces, use [`missing_probabilities`](@ref) otherwise.
 
 See also: [`MissingDispersionPatterns`](@ref).
 """
-function missing_outcomes(o::OutcomeSpace, x)
+function missing_outcomes(o::OutcomeSpace, x; all = nothing)
+    if !isnothing(all)
+        @warn """
+        Tthe keyword `all` has no meaning is deprecated for `missing_outcomes`.
+        """
+    end
     cts = counts(o, x)
     L = total_outcomes(o, x)
     O = count(!iszero, cts)
@@ -391,7 +396,12 @@ Same as [`missing_outcomes`](@ref), but defines a "missing outcome" as an outcom
 having 0 probability according to `est`.
 """
 missing_probabilities(o::OutcomeSpace, x) = missing_probabilities(RelativeAmount(), o, x)
-function missing_probabilities(est::ProbabilitiesEstimator, o::OutcomeSpace, x)
+function missing_probabilities(est::ProbabilitiesEstimator, o::OutcomeSpace, x; all = nothing)
+    if !isnothing(all)
+        @warn """
+        Tthe keyword `all` has no meaning is deprecated for `missing_outcomes`.
+        """
+    end
     probs = probabilities(est, o, x)
     L = total_outcomes(o, x)
     O = count(!iszero, probs)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -124,12 +124,3 @@ function allcounts(args...)
     @warn "`allcounts` is deprecated. Use `allcounts_and_outcomes` instead."
     return first(allcounts_and_outcomes(args...))
 end
-
-function missing_outcomes(est::ProbabilitiesEstimator, o::OutcomeSpace, x; all = true)
-    @warn """
-    `missing_outcomes` cannot be used with a probabilities estimator.
-    Use `missing_probabilities` instead. Furthermore, the keyword `all` has no meaning
-    and is also deprecated.
-    """
-    return missing_probabilities(est, o, x)
-end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -124,3 +124,12 @@ function allcounts(args...)
     @warn "`allcounts` is deprecated. Use `allcounts_and_outcomes` instead."
     return first(allcounts_and_outcomes(args...))
 end
+
+function missing_outcomes(est::ProbabilitiesEstimator, o::OutcomeSpace, x; all = true)
+    @warn """
+    `missing_outcomes` cannot be used with a probabilities estimator.
+    Use `missing_probabilities` instead. Furthermore, the keyword `all` has no meaning
+    and is also deprecated.
+    """
+    return missing_probabilities(est, o, x)
+end

--- a/test/complexity/missing_outcomes.jl
+++ b/test/complexity/missing_outcomes.jl
@@ -1,3 +1,4 @@
+using ComplexityMeasures
 using Test
 using Random
 rng = Xoshiro(1234)
@@ -9,7 +10,7 @@ p = probabilities(est, outcomemodel, x)
 Ω = outcome_space(est, outcomemodel, x)
 
 # With the given `x` and `outcomemodel`, all outcomes should be covered
-@test missing_outcomes(outcomemodel, x; all = true) == 0
+@test missing_outcomes(outcomemodel, x) == 0
 @test missing_outcomes(outcomemodel, x; all = false) == 0
-@test missing_outcomes(est, outcomemodel, x; all = true) == 0
-@test missing_outcomes(est, outcomemodel, x; all = false) == 0
+@test missing_probabilities(est, outcomemodel, x) == 0
+@test missing_probabilities(est, outcomemodel, x; all = false) == 0


### PR DESCRIPTION
This PR simplifies the docstring and source codes of missing dispersion patterns and missing outcomes.

It also sets the `all` keyword of `missing_outomces` to `false`. Why would this be `true`? It is computationally more expensive and leads to the same outcome. Furthermore, I would even argue, why would `all` _ever_ be used? This keyword appears useless at first glance. Perhaps we should deprecate it?