### PR TITLE
Add page that estimates total number of measures in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The key features that it provides can be summarized as:
 - Estimators for other complexity measures that are not estimated based on probability functions.
 - An extendable interface and well thought out API accompanied by dedicated developer documentation pages. These makes it trivial to define new outcome spaces, or new estimators for probabilities, information measures, or complexity measures and integrate them with everything else in the software.
 
-ComplexityMeasures.jl can be used as a standalone package, or as part of other projects in the JuliaDynamics organization, such as [DynamicalSystems.jl](https://juliadynamics.github.io/DynamicalSystems.jl/dev/) or [CausalityTools.jl](https://juliadynamics.github.io/CausalityTools.jl/dev/).
+ComplexityMeasures.jl can be used as a standalone package, or as part of other projects in the JuliaDynamics organization, such as [DynamicalSystems.jl](https://juliadynamics.github.io/DynamicalSystemsDocs.jl/dynamicalsystems/dev/) or [CausalityTools.jl](https://juliadynamics.github.io/CausalityTools.jl/dev/).
 
 To install it, run `import Pkg; Pkg.add("ComplexityMeasures")`.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@
 [![Package Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/Entropies)](https://pkgs.genieframework.com?packages=Entropies)
 [![DOI](https://zenodo.org/badge/306859984.svg)](https://zenodo.org/badge/latestdoi/306859984)
 
-A Julia package that provides:
+ComplexityMeasures.jl is a software measure for calculating 1000s of various kinds of
+probabilities, entropies, and other so-called _complexity measures_ from input data.
+
+The key features that it provides can be summarized as:
 
 - A rigorous framework for extracting probabilities from data, based on the mathematical formulation of [probability spaces](https://en.wikipedia.org/wiki/Probability_space).
 - Several (12+) outcome spaces, i.e., ways to discretize data into probabilities.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,7 @@ using ComplexityMeasures
 # Convert tutorial file to markdown
 import Literate
 Literate.markdown("src/tutorial.jl", "src"; credit = false)
+Literate.markdown("src/measure_count.jl", "src"; credit = false)
 
 pages = [
     "index.md",
@@ -15,6 +16,7 @@ pages = [
     "examples.md",
     "devdocs.md",
     "references.md",
+    hide("measure_count.md"),
 ]
 
 # For easier debugging when downloading from a specific branch.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -41,3 +41,8 @@ In general though, the standard DynamicalSystems.jl approach is taken and as suc
 ```@docs
 StateSpaceSet
 ```
+
+## Total entropy/information/complexity measures
+
+ComplexityMeasures.jl offers thousands of measures computable right out of the box.
+To see an exact number of how many, see this [calculation page](@ref total_measures).

--- a/docs/src/measure_count.jl
+++ b/docs/src/measure_count.jl
@@ -1,0 +1,200 @@
+# # Counting the number of measures in ComplexityMeasures.jl
+
+# In this page we will count all the possible complexity measures
+# than one can compute with the current version of ComplexityMeasures.jl!
+
+using ComplexityMeasures
+import Pkg; Pkg.status("ComplexityMeasures")
+
+# First let's define a function that counts concrete subtypes
+# that we will be re-using to count measures in ComplexityMeasures.jl.
+
+function concrete_subtypes(type::Type)
+    out = Any[]
+    concrete_subtypes!(out, type)
+end
+function concrete_subtypes!(out, type::Type)
+    if !isabstracttype(type)
+        push!(out, type)
+    else
+        foreach(T -> concrete_subtypes!(out, T), subtypes(type))
+    end
+    out
+end
+
+# # Count Based Outcome Spaces
+#
+# Each `OutcomeSpace` is a possible way of discretizing the input data. For the
+# purpose of counting measures, **we treat the an outcome space with different
+# input parameters as the same outcome space overall.**
+
+# Some outcome spaces are count-based. We estimate these separately,
+# because they may be estimated with various different probabilities estimators.
+# For our counting here it doesn't matter whether the outcome space supports
+# spatiotemporal or trajectory (uni/multi variate) date.
+# We only care if it is counting based or not.
+
+OUTCOME_SPACES_COUNT = concrete_subtypes(ComplexityMeasures.CountBasedOutcomeSpace)
+
+# We do a small correction here because two outcome spaces
+# aren't count-based but for internal convenience they satisfy
+# the subtyping relationship
+correction_ospaces = (AmplitudeAwareOrdinalPatterns, WeightedOrdinalPatterns)
+foreach(
+    T -> deleteat!(OUTCOME_SPACES_COUNT, findfirst(isequal(T), OUTCOME_SPACES_COUNT)),
+    correction_ospaces
+)
+
+OUTCOME_SPACES_COUNT
+
+# Probabilities can be estimated from count-based outcome spaces in different
+# ways. We count the same `ProbabilitiesEstimators` with different input
+# parameters as the same estimator. Each probabilities estimator can be
+# combined with any outcome space.
+
+PROBESTS_COUNT = concrete_subtypes(ProbabilitiesEstimator)
+
+# and we count the combinations
+
+n_outcome_spaces_count = length(OUTCOME_SPACES_COUNT)
+n_probests_count = length(PROBESTS_COUNT)
+n_probs_count = n_outcome_spaces_count * n_probests_count
+
+# # Non-count-based outcome spaces
+#
+# We also provide some outcome spaces that are not count-based, but can still
+# be used to estimate discrete probabilities by using some sort of "relative
+# amount" estimation.
+
+OUTCOME_SPACES_NOCOUNT = setdiff(
+    concrete_subtypes(ComplexityMeasures.OutcomeSpace),
+    concrete_subtypes(ComplexityMeasures.CountBasedOutcomeSpace),
+)
+
+# to which we add back the outcome spaces correction
+push!(OUTCOME_SPACES_NOCOUNT, correction_ospaces...)
+OUTCOME_SPACES_NOCOUNT
+
+# Only `RelativeAmount` probabilities estimator works with non-count-based outcome spaces
+n_probs_noncount = length(OUTCOME_SPACES_NOCOUNT) * 1
+
+# # Grand total of extracting PMFs from data
+
+# Therefore the total ways to estimate discrete probabilities from data
+# in ComplexityMeasures.jl is just
+
+n_probs_discrete = n_probs_noncount + n_probs_count
+
+# # Discrete Information measures
+
+# Currently, the InformationMeasures implemented are different types of
+# entropies and the lesser-known extropies. Each of these measures, in their
+# discrete form, are functions of probability mass functions (PMFs).
+# Therefore, we can combine each of these measure with probabilities estimated
+# using any count-based outcome space and any probabilities estimator.
+
+# Let's collect all of these discrete measures
+
+INFO_MEASURES_DISCRETE = concrete_subtypes(InformationMeasure)
+
+# Each information measure can be estimated using any of the generic
+# estimators:
+
+INFO_MEASURE_ESTIMATOR_GENERIC = concrete_subtypes(ComplexityMeasures.DiscreteInfoEstimatorGeneric)
+
+# so we count by multiplying
+
+n_discrete_infoest_generic = length(INFO_MEASURES_DISCRETE)*length(INFO_MEASURE_ESTIMATOR_GENERIC)
+
+
+# In addition to the generic estimators,
+# we also provide additional estimators specific to Shannon entropy.
+INFO_MEASURE_ESTIMATOR_SHANNON = concrete_subtypes(ComplexityMeasures.DiscreteInfoEstimatorShannon)
+
+# For these there is no variability of the information measure so
+n_discrete_estimators_shannon = length(INFO_MEASURE_ESTIMATOR_SHANNON)
+
+# This gives us the total possible ways of estimating information measures
+# given a PMF:
+
+n_discrete_info_est = n_discrete_estimators_shannon + n_discrete_infoest_generic
+
+# # Grand total of discrete information measures
+
+# This total is obtained as the direct multiplication of all ways
+# to obtain a PMF and all ways to compute an information measure from PMF
+
+n_discrete_info = n_discrete_info_est * n_probs_discrete
+
+# That's quite a lot and we are only half-way done!
+
+# # Differential information measures
+
+# The differential information measures and their estimators are
+# all grouped into one level of abstraction as long as the user is concerned,
+# so counting things here is very simple!
+
+DIFF_INFO_EST = concrete_subtypes(DifferentialInfoEstimator)
+
+# All of these estimate one quantity (the differential Shannon entropy),
+# with the exception of one particular estimator (`LeonenkoProzantoSavani`)
+# that can estimate also Tsallis and Renyi entropies.
+# Therefore, the number of differential measures one can estimate within
+# ComplexityMeasures.jl is:
+
+n_diff_info = length(DIFF_INFO_EST) + 2
+
+# # Complexity measures
+#
+# We also provide a number of estimators that are not probability based, which
+# we call just complexity estimators for this discussion.
+# We count each of these as a separate measure.
+
+COMPLEXITY_ESTIMATORS = concrete_subtypes(ComplexityEstimator)
+
+# However, from these we need to treat `StatisticalComplexity` separately, so we have
+
+n_complexity_measures_basic = length(COMPLEXITY_ESTIMATORS) - 1
+
+# In ComplexityMeasures.jl `StatisticalComplexity` can be combined with any discrete
+# information measure and any count-based outcome space.
+# Additionally, `StatisticalComplexity` in ComplexityMeasures.jl can be combined with any
+# metric from the Distances.jl package. Just the distance metric variability itself
+# brings 1000s of additional variability of measures into the package,
+# but for the current discussion we decided to consider the metric used as just a
+# parameter of the `StatisticalComplexity`.
+
+# This gives us all possible statistical complexity measures as:
+n_complexity_measures_statistical_complexity = length(INFO_MEASURES_DISCRETE) * n_probs_count
+
+# which gives us the following total number of complexity estimators
+
+n_complexity_measures_total = n_complexity_measures_basic + n_complexity_measures_statistical_complexity
+
+# # Probabilities functions
+
+# Besides calculating complexity measures, ComplexityMeasures.jl gives the user
+# the unique possibility of accessing the probability mass function directly.
+# As we show in the associated article, this allows rather straightforwardly
+# defining new, or expanding existing, complexity measures. For example,
+# the `MissingDispersionPatterns` is just a wrapper of the `missing_outcomes` function.
+
+# Therefore, we believe it is fair to count a couple of probabilities functions by
+# themselves as additional complexity measures. In particular, we count here
+# the functions `probabilities, allproabilities` as candidates for it,
+# as all other functions of the library are simple processing of these two.
+# Given that each function can work with any type of outcome space
+# and probability estimation technique, we obtain
+
+n_extra_prob_measures = 2 * n_probs_discrete
+
+# # Grand total of measures
+
+# Right, so the grand total of all measures that can be estimated with
+# ComplexityMeasures.jl are:
+
+n_grand_total =
+  n_discrete_info +
+  n_diff_info +
+  n_complexity_measures_total +
+  n_extra_prob_measures

--- a/docs/src/measure_count.jl
+++ b/docs/src/measure_count.jl
@@ -22,7 +22,7 @@ function concrete_subtypes!(out, type::Type)
     out
 end
 
-# # Count Based Outcome Spaces
+# ## Count Based Outcome Spaces
 #
 # Each `OutcomeSpace` is a possible way of discretizing the input data. For the
 # purpose of counting measures, **we treat the an outcome space with different
@@ -60,7 +60,7 @@ n_outcome_spaces_count = length(OUTCOME_SPACES_COUNT)
 n_probests_count = length(PROBESTS_COUNT)
 n_probs_count = n_outcome_spaces_count * n_probests_count
 
-# # Non-count-based outcome spaces
+# ## Non-count-based outcome spaces
 #
 # We also provide some outcome spaces that are not count-based, but can still
 # be used to estimate discrete probabilities by using some sort of "relative
@@ -78,14 +78,14 @@ OUTCOME_SPACES_NOCOUNT
 # Only `RelativeAmount` probabilities estimator works with non-count-based outcome spaces
 n_probs_noncount = length(OUTCOME_SPACES_NOCOUNT) * 1
 
-# # Grand total of extracting PMFs from data
+# ## Grand total of extracting PMFs from data
 
 # Therefore the total ways to estimate discrete probabilities from data
 # in ComplexityMeasures.jl is just
 
 n_probs_discrete = n_probs_noncount + n_probs_count
 
-# # Discrete Information measures
+# ## Discrete Information measures
 
 # Currently, the InformationMeasures implemented are different types of
 # entropies and the lesser-known extropies. Each of these measures, in their
@@ -119,7 +119,7 @@ n_discrete_estimators_shannon = length(INFO_MEASURE_ESTIMATOR_SHANNON)
 
 n_discrete_info_est = n_discrete_estimators_shannon + n_discrete_infoest_generic
 
-# # Grand total of discrete information measures
+# ## Grand total of discrete information measures
 
 # This total is obtained as the direct multiplication of all ways
 # to obtain a PMF and all ways to compute an information measure from PMF
@@ -128,7 +128,7 @@ n_discrete_info = n_discrete_info_est * n_probs_discrete
 
 # That's quite a lot and we are only half-way done!
 
-# # Differential information measures
+# ## Differential information measures
 
 # The differential information measures and their estimators are
 # all grouped into one level of abstraction as long as the user is concerned,
@@ -144,7 +144,7 @@ DIFF_INFO_EST = concrete_subtypes(DifferentialInfoEstimator)
 
 n_diff_info = length(DIFF_INFO_EST) + 2
 
-# # Complexity measures
+# ## Complexity measures
 #
 # We also provide a number of estimators that are not probability based, which
 # we call just complexity estimators for this discussion.
@@ -171,7 +171,7 @@ n_complexity_measures_statistical_complexity = length(INFO_MEASURES_DISCRETE) * 
 
 n_complexity_measures_total = n_complexity_measures_basic + n_complexity_measures_statistical_complexity
 
-# # Probabilities functions
+# ## Probabilities functions
 
 # Besides calculating complexity measures, ComplexityMeasures.jl gives the user
 # the unique possibility of accessing the probability mass function directly.
@@ -188,7 +188,7 @@ n_complexity_measures_total = n_complexity_measures_basic + n_complexity_measure
 
 n_extra_prob_measures = 2 * n_probs_discrete
 
-# # Grand total of measures
+# ## Grand total of measures
 
 # Right, so the grand total of all measures that can be estimated with
 # ComplexityMeasures.jl are:

--- a/docs/src/measure_count.jl
+++ b/docs/src/measure_count.jl
@@ -1,4 +1,4 @@
-# # Counting the number of measures in ComplexityMeasures.jl
+# # [Counting the number of measures in ComplexityMeasures.jl](@id total_measures)
 
 # In this page we will count all the possible complexity measures
 # than one can compute with the current version of ComplexityMeasures.jl!


### PR DESCRIPTION
The page is hidden by default. Let me know if the estimation is accurate. We get about 1,600 measures at the moment.