### PR TITLE
Implement fluctuation complexity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Changelog is kept with respect to version 0.11 of Entropies.jl. From version v2.0 onwards, this package has been renamed to ComplexityMeasures.jl.
 
+## 3.6 
+
+- New information measure: `FluctuationComplexity`.
+
 ## 3.5
 
 - New multiscale API.

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ComplexityMeasures"
 uuid = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/ComplexityMeasures.jl.git"
-version = "3.5.0"
+version = "3.6.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -872,3 +872,14 @@ abstract = {Two-dimensional sample entropy (SampEn2D) is a recently developed me
   doi = {10.1214/07-AOS539},
   URL = {https://doi.org/10.1214/07-AOS539}
 }
+
+@article{Bates1993,
+  title={Measuring complexity using information fluctuation},
+  author={Bates, John E and Shepard, Harvey K},
+  journal={Physics Letters A},
+  volume={172},
+  number={6},
+  pages={416--425},
+  year={1993},
+  publisher={Elsevier}
+}

--- a/docs/src/information_measures.md
+++ b/docs/src/information_measures.md
@@ -36,6 +36,7 @@ ShannonExtropy
 RenyiExtropy
 TsallisExtropy
 ElectronicEntropy
+FluctuationComplexity
 ```
 
 ## Discrete information estimators

--- a/src/information_measure_definitions/fluctuation_complexity.jl
+++ b/src/information_measure_definitions/fluctuation_complexity.jl
@@ -1,0 +1,58 @@
+export FluctuationComplexity
+
+"""
+    FluctuationComplexity <: InformationMeasure
+    FluctuationComplexity(; definition = Shannon(; base = 2), base = 2)
+
+The "fluctuation complexity" quantifies the standard deviation of the information content of the states 
+``\\omega_i`` around some  summary statistic ) of a PMF (an [`InformationMeasure`](@ref). Specifically, given some 
+outcome space ``\\Omega`` with outcomes ``\\omega_i \\in \\Omega`` 
+and a probability mass function ``p(\\Omega) = \\{ p(\\omega_i) \\}_{i=1}^N``, it is defined as
+
+```math
+\\sigma_I(p) := \\sqrt{\\sum_{i=1}^N p_i(I_i - H_*)^2}
+```
+
+where ``I_i = -\\log_{base}(p_i)`` is the information content of the i-th outcome. The type of information measure
+``*`` is controlled by `definition`. 
+
+The `base` controls the base of the logarithm that goes into the information content terms. Make sure that 
+you pick a `base` that is consistent with the base chosen for the `definition` (relevant for e.g. [`Shannon`](@ref)).
+
+## Properties 
+
+If `definition` is the [`Shannon`](@ref) entropy, then we recover 
+the [Shannon-type information fluctuation complexity](https://en.wikipedia.org/wiki/Information_fluctuation_complexity) 
+from [Bates1993](@cite). Then the fluctuation complexity is zero for PMFs with only a single non-zero element, or 
+for the uniform distribution.
+
+If `definition` is not Shannon entropy, then the properties of the measure varies, and does not necessarily share the 
+properties [Bates1993](@cite). 
+
+!!! note "Potential for new research" 
+    As far as we know, using other information measures besides Shannon entropy for the 
+    fluctuation complexity hasn't been explored in the literature yet. Our implementation, however, allows for it.
+    Please inform us if you try some new combinations!
+"""
+struct FluctuationComplexity{M <: InformationMeasure, I <: Integer} <: InformationMeasure
+    definition::M
+    base::I
+
+    function FluctuationComplexity(; definition::D = Shannon(base = 2), base::I = 2) where {D, I}
+        if D isa FluctuationComplexity
+            throw(ArgumentError("Cannot use `FluctuationComplexity` as the summary statistic for `FluctuationComplexity`. Please select some other information measures, like `Shannon`."))
+        end
+        return new{D, I}(definition, base)
+    end
+end
+
+# Fluctuation complexity is zero when p_i = 1/N or when p = (1, 0, 0, ...).
+function information(e::FluctuationComplexity, probs::Probabilities)
+    def = e.definition
+    h = information(def, probs)
+    non0_probs = Iterators.filter(!iszero, vec(probs))
+    logf = log_with_base(e.base)
+    return sqrt(sum(pᵢ * (-logf(pᵢ) - h) ^ 2 for pᵢ in non0_probs))
+end
+
+# The maximum is not generally known.

--- a/src/information_measure_definitions/fluctuation_complexity.jl
+++ b/src/information_measure_definitions/fluctuation_complexity.jl
@@ -5,7 +5,7 @@ export FluctuationComplexity
     FluctuationComplexity(; definition = Shannon(; base = 2), base = 2)
 
 The "fluctuation complexity" quantifies the standard deviation of the information content of the states 
-``\\omega_i`` around some  summary statistic ) of a PMF (an [`InformationMeasure`](@ref). Specifically, given some 
+``\\omega_i`` around some summary statistic ([`InformationMeasure`](@ref)) of a PMF. Specifically, given some 
 outcome space ``\\Omega`` with outcomes ``\\omega_i \\in \\Omega`` 
 and a probability mass function ``p(\\Omega) = \\{ p(\\omega_i) \\}_{i=1}^N``, it is defined as
 

--- a/src/information_measure_definitions/information_measure_definitions.jl
+++ b/src/information_measure_definitions/information_measure_definitions.jl
@@ -12,3 +12,5 @@ include("renyi_extropy.jl")
 
 # Measures that are not strictly entropies nor extropies (but perhaps a combination)
 include("electronic.jl")
+
+include("fluctuation_complexity.jl")

--- a/test/infomeasures/infomeasure_types/fluctuation_complexity.jl
+++ b/test/infomeasures/infomeasure_types/fluctuation_complexity.jl
@@ -1,0 +1,9 @@
+# Examples from https://en.wikipedia.org/wiki/Information_fluctuation_complexity
+# for the Shannon fluctuation complexity.
+p = Probabilities([2//17, 2//17, 1//34, 5//34, 2//17, 2//17, 2//17, 4//17])
+def = Shannon(base = 2)
+c = FluctuationComplexity(definition = def, base = 2)
+@test round(information(c, p), digits = 2) ≈ 0.56 
+# Zero both for uniform and single-element PMFs.
+@test information(c, Probabilities([0.2, 0.2, 0.2, 0.2, 0.2])) == 0.0
+@test information(c, Probabilities([1.0, 0.0])) == 0.0

--- a/test/infomeasures/infomeasures.jl
+++ b/test/infomeasures/infomeasures.jl
@@ -15,6 +15,7 @@ include("infomeasure_types/tsallis_extropy.jl")
 include("infomeasure_types/renyi_extropy.jl")
 
 include("infomeasure_types/electronic_entropy.jl")
+include("infomeasure_types/fluctuation_complexity.jl")
 
 
 # Estimators


### PR DESCRIPTION
## What's this?

The fluctuation complexity characterizes the deviations of the information content of individual states from some summary statistic (information measure) computed for the same distribution. I've here generalized the original measure, which uses Shannon entropy, to be compatible with any `InformationMeasure`.

## Code changes

- Updated changelog and version.
- A bibtex entry for the original reference.
- The `FluctuationComplexity` type, which can be used with `information` in combination with any estimation method, just like the other entropies & friends.
- A documentation entry.
- Analytical tests for the case of using `Shannon` entropy as the summary statistic.
- Note: There's no `information_maximum` method for now, because I couldn't see any of generally computing the maximum value without some finicky additions to the codebase, which I don't want to deal with now.