### PR TITLE
Bug fix in `UniqueElementsEncoding`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ComplexityMeasures"
 uuid = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/ComplexityMeasures.jl.git"
-version = "3.6.4"
+version = "3.6.5"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/encoding_implementations/unique_elements_encoding.jl
+++ b/src/encoding_implementations/unique_elements_encoding.jl
@@ -25,20 +25,21 @@ encode.(Ref(e), x) == [1, 2, 3, 2, 3, 1] # true
 struct UniqueElementsEncoding{T, I <: Integer} <: Encoding
     encode_dict::Dict{T, I}
     decode_dict::Dict{I, T}
-    function UniqueElementsEncoding(x)
-
-        # Ecode in order of first appearance, because `sort` doesn't work if we mix types,
-        # e.g. `String` and `Int`.
-        x_unique = unique(x)
-        encode_dict = Dict{eltype(x), Int}()
-        decode_dict = Dict{Int, eltype(x)}()
-        for (i, xu) in enumerate(x_unique)
-            encode_dict[xu] = i
-            decode_dict[i] = xu
-        end
-        new{eltype(x), Int}(encode_dict, decode_dict)
-    end
 end
+function UniqueElementsEncoding(x)
+    # Ecode in order of first appearance, because `sort` doesn't work if we mix types,
+    # e.g. `String` and `Int`.
+    x_unique = unique(vec(x))
+    T = eltype(x_unique)
+    encode_dict = Dict{T, Int}()
+    decode_dict = Dict{Int, T}()
+    for (i, xu) in enumerate(x_unique)
+        encode_dict[xu] = i
+        decode_dict[i] = xu
+    end
+    return UniqueElementsEncoding(encode_dict, decode_dict)
+end
+
 function UniqueElementsEncoding()
     throw(ArgumentError("`UniqueElementsEncoding` can't be initialized without input data."))
 end
@@ -47,6 +48,6 @@ function encode(encoding::UniqueElementsEncoding, x)
     return encoding.encode_dict[x]
 end
 
-function decode(encoding::UniqueElementsEncoding, ω::Integer)
+function decode(encoding::UniqueElementsEncoding, ω::I) where I <: Integer
     return encoding.decode_dict[ω]
 end

--- a/src/encoding_implementations/unique_elements_encoding.jl
+++ b/src/encoding_implementations/unique_elements_encoding.jl
@@ -27,7 +27,7 @@ struct UniqueElementsEncoding{T, I <: Integer} <: Encoding
     decode_dict::Dict{I, T}
 end
 function UniqueElementsEncoding(x)
-    # Ecode in order of first appearance, because `sort` doesn't work if we mix types,
+    # Encode in order of first appearance, because `sort` doesn't work if we mix types,
     # e.g. `String` and `Int`.
     x_unique = unique(vec(x))
     T = eltype(x_unique)

--- a/src/outcome_spaces/unique_elements.jl
+++ b/src/outcome_spaces/unique_elements.jl
@@ -35,6 +35,7 @@ probabilities(x) = probabilities(UniqueElements(), x)
 outcome_space(::UniqueElements, x) = sort!(unique(x))
 
 function codify(o::UniqueElements, x)
-    encoding = UniqueElementsEncoding(x)
-    return [encode(encoding, xᵢ) for xᵢ in x]
+    xv = vec(x)
+    encoding = UniqueElementsEncoding(xv)
+    encode.(Ref(encoding), xv)
 end

--- a/src/outcome_spaces/unique_elements.jl
+++ b/src/outcome_spaces/unique_elements.jl
@@ -36,5 +36,5 @@ outcome_space(::UniqueElements, x) = sort!(unique(x))
 
 function codify(o::UniqueElements, x)
     encoding = UniqueElementsEncoding(x)
-    encode.(Ref(encoding), x)
+    return [encode(encoding, xᵢ) for xᵢ in x]
 end

--- a/test/encodings/encodings/unique_elements_encoding.jl
+++ b/test/encodings/encodings/unique_elements_encoding.jl
@@ -1,6 +1,11 @@
 using Test
 using ComplexityMeasures
+using statespacesets
 
 x = ['a', 2, 5, 2, 5, 'a']
 e = UniqueElementsEncoding(x)
 @test encode.(Ref(e), x) == [1, 2, 3, 2, 3, 1]
+
+y = StateSpaceSet(["a", "b", "c", "b", "a"])
+ey = UniqueElementsEncoding(y)
+encode.(Ref(ey), y)

--- a/test/encodings/encodings/unique_elements_encoding.jl
+++ b/test/encodings/encodings/unique_elements_encoding.jl
@@ -1,6 +1,6 @@
 using Test
 using ComplexityMeasures
-using statespacesets
+using StateSpaceSets
 
 x = ['a', 2, 5, 2, 5, 'a']
 e = UniqueElementsEncoding(x)

--- a/test/encodings/encodings/unique_elements_encoding.jl
+++ b/test/encodings/encodings/unique_elements_encoding.jl
@@ -2,10 +2,16 @@ using Test
 using ComplexityMeasures
 using StateSpaceSets
 
-x = ['a', 2, 5, 2, 5, 'a']
-e = UniqueElementsEncoding(x)
+x = ['a', 2, 5, 2, 5, 'a']; e = UniqueElementsEncoding(x)
 @test encode.(Ref(e), x) == [1, 2, 3, 2, 3, 1]
 
-y = StateSpaceSet(["a", "b", "c", "b", "a"])
-ey = UniqueElementsEncoding(y)
-encode.(Ref(ey), y)
+y = ["a", "b", "c", "b", "a"]; ey = UniqueElementsEncoding(y)
+@test encode.(Ref(ey), y) == [1, 2, 3, 2, 1]
+
+z = vec(StateSpaceSet(y)); ez = UniqueElementsEncoding(z)
+@test encode.(Ref(ez), z)  == [1, 2, 3, 2, 1]
+
+# TODO: this should really work (but broadcasting fails). The error is not in this package,
+# but is due to lacking broadcasting implementation in StateSpaceSets.jl
+# w = StateSpaceSet(y); ew = UniqueElementsEncoding(w)
+# @test encode.(Ref(ew), w)  == [1, 2, 3, 2, 1]

--- a/test/outcome_spaces/implementations/unique_elements.jl
+++ b/test/outcome_spaces/implementations/unique_elements.jl
@@ -38,4 +38,7 @@ end
 
 # Codification of vector inputs (time series)
 x = [1, 3, 2, 1, 2, 2, 1, 3, 1]
+y = StateSpaceSet(["a", "b", "c", "b", "a"])
+
 @test codify(UniqueElements(), x) isa Vector{Int}
+@test codify(UniqueElements(), y) isa Vector{Int}


### PR DESCRIPTION
While working on the latest version of CausalityTools.jl, I encountered a weird bug that turned out to have its root in ComplexityMeasures.jl: `codify`ing certain types of state space sets with `UniqueElements` didn't work. This happened because the `unique(x)`call errored. In turn, this happens because `unique` isn't implemented for `AbstractStateSpaceSet`s. 

I fix this here by using `vec` to get the data (which works both for regular vectors and for state space sets). This is now tested explicitly. 

I also ensure that we get the correct element types for the dicts, and use an outer constructor because there's nothing special happening in it requiring it to be an inner constructor.