### PR TITLE
Fix erroneous change of constructor signature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 Changelog is kept with respect to version 0.11 of Entropies.jl. From version v2.0 onwards, this package has been renamed to ComplexityMeasures.jl.
 
-## 3.8
-
-- Fixed a bug in the `Probabilities` constructor. It is now again possible to construct `Probabilities`
-  when outcome vectors have different element types.
- 
 ## 3.7
 
 - Updated to StateSpaceSets.jl v2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Changelog is kept with respect to version 0.11 of Entropies.jl. From version v2.0 onwards, this package has been renamed to ComplexityMeasures.jl.
 
+## 3.8
+
+- Fixed a bug in the `Probabilities` constructor. It is now again possible to construct `Probabilities`
+  when outcome vectors have different element types.
+ 
 ## 3.7
 
 - Updated to StateSpaceSets.jl v2.0

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ComplexityMeasures"
 uuid = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/ComplexityMeasures.jl.git"
-version = "3.7.0"
+version = "3.8.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ComplexityMeasures"
 uuid = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/ComplexityMeasures.jl.git"
-version = "3.8.0"
+version = "3.7.1"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/core/probabilities.jl
+++ b/src/core/probabilities.jl
@@ -57,7 +57,7 @@ struct Probabilities{T, N, S} <: AbstractArray{T, N}
     dimlabels::NTuple{N, S}
 
     function Probabilities(x::AbstractArray{T, N},
-            outcomes::Tuple{Vararg{V, N}} where V,
+            outcomes::Tuple{Vararg{V, N} where V},
             dimlabels::NTuple{N, S};
             normed::Bool = false) where {T, N, S}
         if !normed # `normed` is an internal argument that skips checking the sum.

--- a/test/probabilities/probabilities.jl
+++ b/test/probabilities/probabilities.jl
@@ -11,6 +11,11 @@ outs = collect(1:10)
 @test Probabilities(rand(rng, 10), (outs,)) isa Probabilities
 @test Probabilities(rand(rng, 10), (outs,), (:x1, )) isa Probabilities
 
+# outcome vectors for different eltypes
+outs1 = ["a", "b"]; outs2 = [1, 2];
+cts = rand(1:10, 2, 2);
+@test Probabilities(cts, (outs1, outs2)) isa Probabilities
+
 # ----------------------------------------------------------------
 # Base extensions 
 # ----------------------------------------------------------------


### PR DESCRIPTION
https://github.com/JuliaDynamics/ComplexityMeasures.jl/pull/422 changed the following

```Julia
  function Probabilities(x::AbstractArray{T, N},
            outcomes::Tuple{Vararg{V, N} where V},
            dimlabels::NTuple{N, S};
            normed::Bool = false)
```

to 

```Julia
 function Probabilities(x::AbstractArray{T, N},
            outcomes::Tuple{Vararg{V, N}} where V,
            dimlabels::NTuple{N, S};
            normed::Bool = false)
```

The change was `outcomes::Tuple{Vararg{V, N} where V}` => `outcomes::Tuple{Vararg{V, N}} where V`. 

The first part of the PR does address the deprecation warning the PR was supposed to solve (https://github.com/JuliaDynamics/ComplexityMeasures.jl/issues/419). However, the second change (the above), is not related to the deprecation warning. More seriously, this fundamentally changes the meaning of the type annotation, which has functional consequences for code that depends on this constructor: 
- `Tuple{Vararg{V, N} where V}` (with the `where V` inside the outer brackets) allows the element type of the outcome vectors to be variables (e.g. the first outcome vector may be a Vector{Int}, while the second may be Vector{String}).
-   `Tuple{Vararg{V, N}} where V` (with the `where V` outside the outer brackets) enforces identical element types for all outcome vectors.

Upstream in Associations.jl, this means that we can't do categorical probability estimation with input vectors of arbitrary `eltype` any longer. In turn, this breaks many discrete probabilities-based association based measures. 

I'm here reverting the change and merging immediately. 

@max-de-rooij, I'm not sure if you were aware of this distinction, so I'm tagging you here to let you know. And to be clear: you are not to blame for this error. We should have caught it during the PR review :) 

@Datseris  The reason we didn't catch this is that we don't explicitly test anything that uses this distinction in ComplexityMeasures.jl. We implement and test multivariate probabilities estimation in Associations.jl, not here. I first caught this while upgrading the combat for ComplexityMeasures.jl to v3.7 in Associations.jl (where the tests *did* fail).



