### PR TITLE
Fix deprecation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ComplexityMeasures"
 uuid = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/ComplexityMeasures.jl.git"
-version = "3.7.1"
+version = "3.7.2"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/core/probabilities.jl
+++ b/src/core/probabilities.jl
@@ -57,7 +57,7 @@ struct Probabilities{T, N, S} <: AbstractArray{T, N}
     dimlabels::NTuple{N, S}
 
     function Probabilities(x::AbstractArray{T, N},
-            outcomes::Tuple{Vararg{V, N} where V},
+            outcomes::Tuple{Vararg{AbstractVector, N}},
             dimlabels::NTuple{N, S};
             normed::Bool = false) where {T, N, S}
         if !normed # `normed` is an internal argument that skips checking the sum.

--- a/src/probabilities_estimators/AddConstant.jl
+++ b/src/probabilities_estimators/AddConstant.jl
@@ -70,7 +70,6 @@ function probs_and_outs_from_histogram(est::AddConstant, outcomemodel::OutcomeSp
     for (k, nₖ) in enumerate(cts)
         probs[k] = (nₖ + c) / (n + (c * m))
     end
-    @assert sum(probs) ≈ 1
-
+    
     return Probabilities(probs, outs,)
 end

--- a/src/probabilities_estimators/AddConstant.jl
+++ b/src/probabilities_estimators/AddConstant.jl
@@ -70,6 +70,7 @@ function probs_and_outs_from_histogram(est::AddConstant, outcomemodel::OutcomeSp
     for (k, nₖ) in enumerate(cts)
         probs[k] = (nₖ + c) / (n + (c * m))
     end
+    @assert sum(probs) ≈ 1
     
     return Probabilities(probs, outs,)
 end


### PR DESCRIPTION
In #427, I fixed the error disallowing different-type outcome containers for `Probabilities`. However, that introduced the deprecation warning again. This fixes the resulting deprecations warning.