### PR TITLE
Fix ambiguous methods for codify

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ComplexityMeasures"
 uuid = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/ComplexityMeasures.jl.git"
-version = "3.7.2"
+version = "3.7.3"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/core/encodings.jl
+++ b/src/core/encodings.jl
@@ -49,12 +49,8 @@ export codify
 """
 
     codify(o::OutcomeSpace, x::Vector) → s::Vector{Int}
-    codify(o::OutcomeSpace, x::AbstractStateSpaceSet{D}) → s::NTuple{D, Vector{Int}
 
 Codify `x` according to the outcome space `o`.
-If `x` is a `Vector`, then a `Vector{<:Integer}` is returned. If `x` is a
-`StateSpaceSet{D}`, then symbolization is done column-wise and an
-`NTuple{D, Vector{<:Integer}}` is returned, where `D = dimension(x)`.
 
 ## Description
 
@@ -69,6 +65,4 @@ spaces preserve the input data length (e.g. [`UniqueElements`](@ref)), while
 some outcome spaces (e.g. [`OrdinalPatterns`](@ref)) do e.g. delay embeddings before
 encoding, so that `length(s) < length(x)`.
 """
-function codify(o::OutcomeSpace, s::AbstractStateSpaceSet)
-    return map(x -> codify(o, x), columns(s))
-end
+function codify(o::OutcomeSpace, x) end

--- a/src/outcome_spaces/ordinal_patterns.jl
+++ b/src/outcome_spaces/ordinal_patterns.jl
@@ -335,7 +335,7 @@ function fasthist!(πs::Vector{Int}, est::OrdinalOutcomeSpace{m}, x::AbstractSta
     return cts
 end
 
-function codify(o::OrdinalOutcomeSpace{m}, x::AbstractVector{<:Real}) where {m}
+function codify(o::OrdinalOutcomeSpace{m}, x::AbstractVector) where {m}
     emb = embed(x, m, o.τ).data
     return encode.(Ref(o.encoding), emb)
 end

--- a/src/outcome_spaces/value_binning.jl
+++ b/src/outcome_spaces/value_binning.jl
@@ -95,7 +95,7 @@ function codify(o::ValueBinning{<:FixedRectangularBinning}, x::AbstractStateSpac
     return encode.(Ref(encoder), x.data)
 end
 
-function codify(o::ValueBinning{<:RectangularBinning}, x::AbstractVector{<:Real})
+function codify(o::ValueBinning{<:RectangularBinning}, x::AbstractVector)
     encoder = RectangularBinEncoding(o.binning, x)
     return encode.(Ref(encoder), x)
 end

--- a/test/outcome_spaces/implementations/permutation.jl
+++ b/test/outcome_spaces/implementations/permutation.jl
@@ -95,7 +95,4 @@ end
     s = StateSpaceSet(x, y)
     c1 = codify(S(), x)
     @test c1 isa Vector{Int}
-    out = codify(S(), s)
-    @test out isa Tuple
-    @test out[1] == c1
 end


### PR DESCRIPTION
Fixes #429. 

## Changes: 

- Remove all codify methods that dispatch explicitly on `AbstractStateSpaceSet`. 

This has no effect on any functionality in ComplexityMeasures.jl, but fixes some method ambiguity errors in Associations.jl.