### PR TITLE
Fix warning on Julia 1.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ComplexityMeasures"
 uuid = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/ComplexityMeasures.jl.git"
-version = "3.8.2"
+version = "3.8.3"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/core/outcome.jl
+++ b/src/core/outcome.jl
@@ -17,7 +17,7 @@ Base.show(io::IO, o::Outcome) = print(io, "Outcome($(o.num))")
 
 # Some necessary methods for ranges to work.
 Outcome{T}(x::Outcome{T}) where T<:Integer = Outcome(x.num)
-Integer(x::Outcome{T}) where T<:Integer = x.num
+Base.Integer(x::Outcome{T}) where T<:Integer = x.num
 
 import Base: -, +, *, rem, div, inv
 for f in [:(*), :(+), :(-), :rem, :div]


### PR DESCRIPTION
When loading ComplexityMeasures on Julia 1.12, the following warning is shown:

```julia
julia> using ComplexityMeasures
...
┌ ComplexityMeasures
│  WARNING: Constructor for type "Integer" was extended in `ComplexityMeasures` without explicit qualification or import.
│    NOTE: Assumed "Integer" refers to `Base.Integer`. This behavior is deprecated and may differ in future versions.`
│    NOTE: This behavior may have differed in Julia versions prior to 1.12.
│    Hint: If you intended to create a new generic function of the same name, use `function Integer end`.
│    Hint: To silence the warning, qualify `Integer` as `Base.Integer` in the method signature or explicitly `import Base: Integer`.
```

The PR fixes this issue by qualifying `Integer` as `Base.Integer`, as suggested in the warning.